### PR TITLE
Removed basic auth from email verification endpoint

### DIFF
--- a/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
@@ -125,7 +125,7 @@ public class VerificationResource {
         new StringJoiner("\n")
           .add("<h1> Welcome to Pilot! </h1>")
           .add("<p> Click the below link to verify your account. </p>")
-          .add(String.format("<a href=\"thunder.sanctionco.com/verify?email=%s&token=%s\">"
+          .add(String.format("<a href=\"http://thunder.sanctionco.com/verify?email=%s&token=%s\">"
             + "Click here to verify your account!</a>",
             result.getEmail().getAddress(),
             token))
@@ -149,14 +149,12 @@ public class VerificationResource {
   /**
    * Verifies the provided email, setting it as valid in the database.
    *
-   * @param key The basic authentication key necessary to access the resource.
    * @param email The email to verify in the database.
    * @param token The verification token associated with the user.
    * @return A response status and message.
    */
   @GET
-  public Response verifyEmail(@Auth Key key,
-                              @QueryParam("email") String email,
+  public Response verifyEmail(@QueryParam("email") String email,
                               @QueryParam("token") String token) {
     verifyEmailRequests.mark();
 

--- a/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
+++ b/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
@@ -10,8 +10,6 @@ import com.sanction.thunder.email.EmailService;
 import com.sanction.thunder.models.Email;
 import com.sanction.thunder.models.PilotUser;
 
-import java.util.StringJoiner;
-
 import javax.ws.rs.core.Response;
 import org.junit.Test;
 
@@ -110,14 +108,14 @@ public class VerificationResourceTest {
   /* Verify Email Tests */
   @Test
   public void testVerifyEmailWithNullEmail() {
-    Response response = resource.verifyEmail(key, null, "verificationToken");
+    Response response = resource.verifyEmail(null, "verificationToken");
 
     assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
   }
 
   @Test
   public void testVerifyEmailWithNullToken() {
-    Response response = resource.verifyEmail(key, "test@test.com", null);
+    Response response = resource.verifyEmail("test@test.com", null);
 
     assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
   }
@@ -127,7 +125,7 @@ public class VerificationResourceTest {
     when(usersDao.findByEmail(anyString()))
         .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
 
-    Response response = resource.verifyEmail(key, "test@test.com", "verificationToken");
+    Response response = resource.verifyEmail("test@test.com", "verificationToken");
 
     assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
   }
@@ -136,7 +134,7 @@ public class VerificationResourceTest {
   public void testVerifyEmailWithNullDatabaseToken() {
     when(usersDao.findByEmail(anyString())).thenReturn(nullDatabaseTokenMockUser);
 
-    Response response = resource.verifyEmail(key, "test@test.com", "verificationToken");
+    Response response = resource.verifyEmail("test@test.com", "verificationToken");
 
     assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
   }
@@ -145,7 +143,7 @@ public class VerificationResourceTest {
   public void testVerifyEmailWithMismatchedToken() {
     when(usersDao.findByEmail(anyString())).thenReturn(mismatchedTokenMockUser);
 
-    Response response = resource.verifyEmail(key, "test@test.com", "verificationToken");
+    Response response = resource.verifyEmail("test@test.com", "verificationToken");
 
     assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
   }
@@ -156,7 +154,7 @@ public class VerificationResourceTest {
     when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
         .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
 
-    Response response = resource.verifyEmail(key, "test@test.com", "verificationToken");
+    Response response = resource.verifyEmail("test@test.com", "verificationToken");
 
     assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
   }
@@ -167,7 +165,7 @@ public class VerificationResourceTest {
     when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
         .thenReturn(verifiedMockUser);
 
-    Response response = resource.verifyEmail(key, "test@test.com", "verificationToken");
+    Response response = resource.verifyEmail("test@test.com", "verificationToken");
     PilotUser result = (PilotUser) response.getEntity();
 
     assertEquals(response.getStatusInfo(), Response.Status.OK);

--- a/scripts/tester.py
+++ b/scripts/tester.py
@@ -74,7 +74,6 @@ if __name__ == '__main__':
     # Verify
     print('Attempting to verify the created user...')
     data = requests.verify_user(args.endpoint + '/verify',
-                                authentication=auth,
                                 params={'email': data['email']['address'],
                                         'token': data['email']['verificationToken']},
                                 headers={'password': data['password']},

--- a/scripts/thunder_requests/methods.py
+++ b/scripts/thunder_requests/methods.py
@@ -47,9 +47,9 @@ def add_user(endpoint, authentication, body, verbose=False):
 
 
 # Verifies the user email address
-def verify_user(endpoint, authentication, params, headers, verbose=False):
+def verify_user(endpoint, params, headers, verbose=False):
     try:
-        r = requests.get(endpoint, auth=authentication, params=params, headers=headers)
+        r = requests.get(endpoint, params=params, headers=headers)
     except requests.exceptions.RequestException:
         print('Unable to connect to the supplied endpoint.')
         return False


### PR DESCRIPTION
- Basic auth shouldn't be a requirement for users clicking the link in their browser
- Also changed the url format sent to the user to include the http:// protocol definition