### PR TITLE
Use configuration for email endpoint and Python test enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,17 @@ Thunder is part of the backend for [Pilot](https://github.com/RohanNagar/pilot-o
   The user will be deleted in the database,
   and the response will contain the PilotUser object that was just deleted.
 
+- `POST` `/verify?email=sampleuser@sanctionco.com`
+
+  A POST request sent to the verify endpoint is used to initiate a user verification process by
+  sending a verification email to the email address provided as a query parameter. The password of
+  the user must be included as a header parameter. The user in the database will be updated to
+  include a unique verification token that is sent along with the email.
+
 - `GET` `/verify?email=sampleuser@sanctionco.com&token=12345`
 
-  The verify endpoint is used to verify a user email. The endpoint is called with an email address
-  and a verification token that is sent to the user via email when the account is created.
+  A GET request sent to the verify endpoint is used to verify a user email. The endpoint is called
+  with an email address and a verification token that has been sent to the user via email.
   Upon verification, the user object in the database will be updated to indicate that the email address
   is verified.
 

--- a/application/src/main/java/com/sanction/thunder/ThunderApplication.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderApplication.java
@@ -3,8 +3,8 @@ package com.sanction.thunder;
 import com.sanction.thunder.authentication.Key;
 import com.sanction.thunder.dao.DaoModule;
 import com.sanction.thunder.dynamodb.DynamoDbModule;
-
 import com.sanction.thunder.email.EmailModule;
+
 import io.dropwizard.Application;
 import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.auth.AuthValueFactoryProvider;
@@ -28,8 +28,8 @@ public class ThunderApplication extends Application<ThunderConfiguration> {
     ThunderComponent component = DaggerThunderComponent.builder()
         .daoModule(new DaoModule())
         .dynamoDbModule(new DynamoDbModule(config.getDynamoTableName()))
+        .emailModule(new EmailModule(config.getEmailConfiguration()))
         .thunderModule(new ThunderModule(env.metrics(), config))
-        .emailModule(new EmailModule())
         .build();
 
     // Authentication

--- a/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
@@ -3,6 +3,7 @@ package com.sanction.thunder;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sanction.thunder.authentication.Key;
 
+import com.sanction.thunder.email.EmailConfiguration;
 import io.dropwizard.Configuration;
 
 import java.util.List;
@@ -18,6 +19,15 @@ class ThunderConfiguration extends Configuration {
 
   String getDynamoTableName() {
     return dynamoTableName;
+  }
+
+  @NotNull
+  @Valid
+  @JsonProperty("ses")
+  private final EmailConfiguration emailConfiguration = null;
+
+  public EmailConfiguration getEmailConfiguration() {
+    return emailConfiguration;
   }
 
   @NotNull

--- a/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
@@ -1,0 +1,31 @@
+package com.sanction.thunder.email;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.validator.constraints.NotEmpty;
+
+public class EmailConfiguration {
+
+  @NotEmpty
+  @JsonProperty("endpoint")
+  private final String endpoint = null;
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  @NotEmpty
+  @JsonProperty("region")
+  private final String region = null;
+
+  public String getRegion() {
+    return region;
+  }
+
+  @NotEmpty
+  @JsonProperty("from-address")
+  private final String fromAddress = null;
+
+  public String getFromAddress() {
+    return fromAddress;
+  }
+}

--- a/application/src/main/java/com/sanction/thunder/email/EmailModule.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailModule.java
@@ -1,5 +1,6 @@
 package com.sanction.thunder.email;
 
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder;
 import dagger.Module;
@@ -9,24 +10,33 @@ import javax.inject.Singleton;
 
 @Module
 public class EmailModule {
+  private final String endpoint;
+  private final String region;
+  private final String fromAddress;
 
   /**
-   * Supplies singleton AmazonSimpleEmailService instance for dependency injection.
+   * Constructs a new EmailModule object.
    *
-   * @return An AmazonSimpleEmailService instance.
+   * @param emailConfiguration The configuration to get SES information from
    */
+  public EmailModule(EmailConfiguration emailConfiguration) {
+    this.endpoint = emailConfiguration.getEndpoint();
+    this.region = emailConfiguration.getRegion();
+    this.fromAddress = emailConfiguration.getFromAddress();
+  }
+
   @Singleton
   @Provides
-  public AmazonSimpleEmailService provideAmazonSimpleEmailService() {
+  AmazonSimpleEmailService provideAmazonSimpleEmailService() {
     return AmazonSimpleEmailServiceClientBuilder.standard()
-        .withRegion("us-east-1")
+        .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
         .build();
   }
 
   @Singleton
   @Provides
-  public EmailService provideEmailService(AmazonSimpleEmailService emailService) {
-    return new EmailService(emailService);
+  EmailService provideEmailService(AmazonSimpleEmailService emailService) {
+    return new EmailService(emailService, fromAddress);
   }
 
 }

--- a/application/src/main/java/com/sanction/thunder/email/EmailService.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailService.java
@@ -15,15 +15,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class EmailService {
-
   private static final Logger LOG = LoggerFactory.getLogger(EmailService.class);
-  private static final String FROM = "noreply@sanctionco.com";
 
   private final AmazonSimpleEmailService emailService;
+  private final String fromAddress;
 
   @Inject
-  public EmailService(AmazonSimpleEmailService emailService) {
+  public EmailService(AmazonSimpleEmailService emailService, String fromAddress) {
     this.emailService = emailService;
+    this.fromAddress = fromAddress;
   }
 
   /**
@@ -51,13 +51,13 @@ public class EmailService {
     Message message = new Message().withSubject(subjectText).withBody(body);
 
     SendEmailRequest request = new SendEmailRequest()
-        .withSource(FROM).withDestination(destination)
+        .withSource(fromAddress).withDestination(destination)
         .withMessage(message);
 
     try {
       emailService.sendEmail(request);
     } catch (AmazonClientException e) {
-      LOG.error("There was an error sending email to {}", to.getAddress());
+      LOG.error("There was an error sending email to {}", to.getAddress(), e);
       return false;
     }
 

--- a/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
@@ -139,7 +139,8 @@ public class VerificationResource {
 
     if (!emailResult) {
       LOG.error("Error sending email to address {}", result.getEmail().getAddress());
-      return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+          .entity("An error occurred while attempting to send an email.").build();
     }
 
     LOG.info("Successfully sent verification email to user {}.", email);

--- a/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
@@ -4,8 +4,10 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 
 import com.sanction.thunder.dynamodb.DynamoDbHealthCheck;
+import com.sanction.thunder.email.EmailConfiguration;
 import com.sanction.thunder.resources.UserResource;
 
+import com.sanction.thunder.resources.VerificationResource;
 import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
 import io.dropwizard.setup.Environment;
@@ -32,6 +34,7 @@ public class ThunderApplicationTest {
   private final HealthCheckRegistry healthChecks = mock(HealthCheckRegistry.class);
   private final MetricRegistry metrics = mock(MetricRegistry.class);
   private final ThunderConfiguration config = mock(ThunderConfiguration.class);
+  private final EmailConfiguration emailConfig = mock(EmailConfiguration.class);
 
   private final ThunderApplication application = new ThunderApplication();
 
@@ -41,9 +44,13 @@ public class ThunderApplicationTest {
     when(environment.healthChecks()).thenReturn(healthChecks);
     when(environment.metrics()).thenReturn(metrics);
 
+    when(emailConfig.getEndpoint()).thenReturn("http://localhost");
+    when(emailConfig.getRegion()).thenReturn("us-east-1");
+
     // ThunderConfiguration NotNull fields
     when(config.getApprovedKeys()).thenReturn(new ArrayList<>());
     when(config.getDynamoTableName()).thenReturn("dynamo-table-name");
+    when(config.getEmailConfiguration()).thenReturn(emailConfig);
   }
 
   @Test
@@ -61,5 +68,6 @@ public class ThunderApplicationTest {
 
     assertEquals(1, values.stream().filter(v -> v instanceof AuthDynamicFeature).count());
     assertEquals(1, values.stream().filter(v -> v instanceof UserResource).count());
+    assertEquals(1, values.stream().filter(v -> v instanceof VerificationResource).count());
   }
 }

--- a/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
@@ -22,6 +22,9 @@ public class ThunderConfigurationTest {
         FixtureHelpers.fixture("fixtures/config.yaml"), ThunderConfiguration.class);
 
     assertEquals("sample-table", configuration.getDynamoTableName());
+    assertEquals("test.email.com", configuration.getEmailConfiguration().getEndpoint());
+    assertEquals("test-region", configuration.getEmailConfiguration().getRegion());
+    assertEquals("test@sanctionco.com", configuration.getEmailConfiguration().getFromAddress());
     assertEquals(
         Arrays.asList(new Key("test-app", "test-secret")),
         configuration.getApprovedKeys());

--- a/application/src/test/java/com/sanction/thunder/email/EmailServiceTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/EmailServiceTest.java
@@ -2,53 +2,35 @@ package com.sanction.thunder.email;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
-import com.amazonaws.services.simpleemail.model.Body;
-import com.amazonaws.services.simpleemail.model.Content;
-import com.amazonaws.services.simpleemail.model.Destination;
-import com.amazonaws.services.simpleemail.model.Message;
-import com.amazonaws.services.simpleemail.model.SendEmailRequest;
-
 import com.amazonaws.services.simpleemail.model.SendEmailResult;
+
 import com.sanction.thunder.models.Email;
 
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
+
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class EmailServiceTest {
-
-  private final AmazonSimpleEmailService emailService = mock(AmazonSimpleEmailService.class);
-  private final AmazonClientException clientException = mock(AmazonClientException.class);
-  private final SendEmailResult result = mock(SendEmailResult.class);
-
-  private static final String FROM = "noreply@sanctionco.com";
   private static final String SUBJECT_STRING = "Account Verification";
   private static final String HTML_BODY_STRING = "HTML";
   private static final String BODY_STRING = "TEXT";
 
-  private final Content subjectText = new Content().withCharset("UTF-8").withData(SUBJECT_STRING);
-  private final Content htmlBodyText =
-      new Content().withCharset("UTF-8").withData(HTML_BODY_STRING);
-  private final Content bodyText = new Content().withCharset("UTF-8").withData(BODY_STRING);
+  private final AmazonSimpleEmailService emailService = mock(AmazonSimpleEmailService.class);
+  private final SendEmailResult result = mock(SendEmailResult.class);
 
   private final Email mockEmail = new Email("test@test.com", false, "verificationToken");
-  private final Destination mockDestination = new Destination()
-      .withToAddresses(mockEmail.getAddress());
-  private final Body mockBody = new Body().withHtml(htmlBodyText).withText(bodyText);
-  private final Message mockMessage = new Message().withSubject(subjectText).withBody(mockBody);
-  private final SendEmailRequest mockRequest = new SendEmailRequest()
-      .withSource(FROM)
-      .withDestination(mockDestination)
-      .withMessage(mockMessage);
 
-  private final EmailService resource = new EmailService(emailService);
+  private final EmailService resource = new EmailService(emailService, "testAddress");
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testSendEmailAmazonClientException() {
-    when(emailService.sendEmail(mockRequest)).thenThrow(clientException);
+    when(emailService.sendEmail(any())).thenThrow(AmazonClientException.class);
 
     boolean result = resource.sendEmail(mockEmail, SUBJECT_STRING, HTML_BODY_STRING, BODY_STRING);
 
@@ -57,7 +39,7 @@ public class EmailServiceTest {
 
   @Test
   public void testSendEmailSuccess() {
-    when(emailService.sendEmail(mockRequest)).thenReturn(result);
+    when(emailService.sendEmail(any())).thenReturn(result);
 
     boolean result = resource.sendEmail(mockEmail, SUBJECT_STRING, HTML_BODY_STRING, BODY_STRING);
 

--- a/application/src/test/resources/fixtures/config.yaml
+++ b/application/src/test/resources/fixtures/config.yaml
@@ -1,5 +1,10 @@
 dynamo-table-name: sample-table
 
+ses:
+  endpoint: test.email.com
+  region: test-region
+  from-address: test@sanctionco.com
+
 approved-keys:
   - application: test-app
     secret: test-secret

--- a/config.yaml
+++ b/config.yaml
@@ -1,24 +1,30 @@
 # Information to access DynamoDB
 dynamo-table-name: pilot-users-test
 
+# Information to access SES
+ses:
+  endpoint: email.us-east-1.amazonaws.com
+  region: us-east-1
+  from-address: noreply@sanctionco.com
+
 # Approved Application Authentication Credentials
 approved-keys:
   - application: lightning
-    secret: secret
+    secret:
 
 # Server configuration
 server:
-    applicationConnectors:
-        - type: http
-          port: 8080
-    adminConnectors:
-        - type: http
-          port: 8081
-    requestLog:
-        appenders:
-          - type: file
-            currentLogFilename: /var/log/thunder/thunder-requests.log
-            archivedLogFilenamePattern: /var/log/thunder/thunder-requests-%d.log
+  applicationConnectors:
+    - type: http
+      port: 8080
+  adminConnectors:
+    - type: http
+      port: 8081
+  requestLog:
+    appenders:
+      - type: file
+        currentLogFilename: /var/log/thunder/thunder-requests.log
+        archivedLogFilenamePattern: /var/log/thunder/thunder-requests-%d.log
 
 logging:
   level: INFO

--- a/local-config.yaml
+++ b/local-config.yaml
@@ -1,6 +1,12 @@
 # Information to access DynamoDB
 dynamo-table-name: pilot-users-test
 
+# Information to access SES
+ses:
+  endpoint: email.us-east-1.amazonaws.com
+  region: us-east-1
+  from-address: noreply@sanctionco.com
+
 # Approved Application Authentication Credentials
 approved-keys:
   - application: application
@@ -8,9 +14,9 @@ approved-keys:
 
 # Server configuration
 server:
-    applicationConnectors:
-        - type: http
-          port: 8080
-    adminConnectors:
-        - type: http
-          port: 8081
+  applicationConnectors:
+    - type: http
+      port: 8080
+  adminConnectors:
+    - type: http
+      port: 8081

--- a/scripts/tester.py
+++ b/scripts/tester.py
@@ -106,10 +106,12 @@ if __name__ == '__main__':
 
     print()
 
-    for test in test_pipeline:
-        user_details = test(user_details)
+    result = user_details
 
-        if not user_details:
+    for test in test_pipeline:
+        result = test(result)
+
+        if not result:
             print('Attempting to clean up from failure by deleting user...')
 
             if not delete(user_details):

--- a/scripts/tester.py
+++ b/scripts/tester.py
@@ -58,7 +58,6 @@ if __name__ == '__main__':
     def verify(data):
         print('Attempting to verify the created user...')
         return requests.verify_user(args.endpoint + '/verify',
-                                    authentication=auth,
                                     params={'email': data['email']['address'],
                                             'token': data['email']['verificationToken']},
                                     headers={'password': data['password']},

--- a/scripts/tester.py
+++ b/scripts/tester.py
@@ -8,11 +8,6 @@ import thunder_requests.methods as requests
 from pprint import pprint
 
 
-def terminate():
-    print('Aborting Test...')
-    sys.exit(1)
-
-
 if __name__ == '__main__':
     parser = argparse.ArgumentParser('Script to add a user via Thunder')
 
@@ -34,99 +29,92 @@ if __name__ == '__main__':
     script = os.path.dirname(__file__)
     file_path = os.path.join(script, args.filename)
     with open(file_path) as f:
-        data = json.load(f)
+        user_details = json.load(f)
 
-    # --- Begin test ---
+    # --- Define tests ---
+    def create(data):
+        print('Attempting to create a new user...')
+        return requests.add_user(args.endpoint + '/users',
+                                 authentication=auth,
+                                 body=data,
+                                 verbose=args.verbose)
+
+    def get(data):
+        print('Attempting to get the user...')
+        return requests.get_user(args.endpoint + '/users',
+                                 authentication=auth,
+                                 params={'email': data['email']['address']},
+                                 headers={'password': data['password']},
+                                 verbose=args.verbose)
+
+    def email(data):
+        print('Attempting to send a verification email...')
+        return requests.send_email(args.endpoint + '/verify',
+                                   authentication=auth,
+                                   params={'email': data['email']['address']},
+                                   headers={'password': data['password']},
+                                   verbose=args.verbose)
+
+    def verify(data):
+        print('Attempting to verify the created user...')
+        return requests.verify_user(args.endpoint + '/verify',
+                                    authentication=auth,
+                                    params={'email': data['email']['address'],
+                                            'token': data['email']['verificationToken']},
+                                    headers={'password': data['password']},
+                                    verbose=args.verbose)
+
+    def update_field(data):
+        print('Attempting to update the user\'s Facebook access token...')
+
+        data['facebookAccessToken'] = 'NEWFacebookAccessToken'
+        return requests.update_user(args.endpoint + '/users',
+                                    authentication=auth,
+                                    params={},
+                                    body=data,
+                                    headers={'password': data['password']},
+                                    verbose=args.verbose)
+
+    def update_email(data):
+        print('Attempting to update the user\'s email address...')
+
+        existing_email = data['email']['address']
+        data['email']['address'] = 'newemail@gmail.com'
+        return requests.update_user(args.endpoint + '/users',
+                                    authentication=auth,
+                                    params={'email': existing_email},
+                                    body=data,
+                                    headers={'password': data['password']},
+                                    verbose=args.verbose)
+
+    def delete(data):
+        print('Attempting to delete the user...')
+        return requests.delete_user(args.endpoint + '/users',
+                                    authentication=auth,
+                                    params={'email': data['email']['address']},
+                                    headers={'password': data['password']},
+                                    verbose=args.verbose)
+
+    test_pipeline = [create, get, email, verify, update_field, get, update_email, get, delete]
+
+    # --- Run tests ---
     print('Running Full Thunder Test...')
     if args.verbose:
         print()
-        print('Using user {}:'.format(data['email']['address']))
-        pprint(data)
+        print('Using user {}:'.format(user_details['email']['address']))
+        pprint(user_details)
 
     print()
 
-    # Make POST request
-    print('Attempting to create the new user...')
-    data = requests.add_user(args.endpoint + '/users',
-                             authentication=auth,
-                             body=data,
-                             verbose=args.verbose)
+    for test in test_pipeline:
+        user_details = test(user_details)
 
-    if not data:
-        terminate()
+        if not user_details:
+            print('Attempting to clean up from failure by deleting user...')
 
-    # Make GET request
-    print('Attempting to get the created user...')
-    data = requests.get_user(args.endpoint + '/users',
-                             authentication=auth,
-                             params={'email': data['email']['address']},
-                             headers={'password': data['password']},
-                             verbose=args.verbose)
+            if not delete(user_details):
+                print('** NOTE: Deletion failure means this user is still in the DB. **\n'
+                      '** NOTE: Delete manually or with `thunder_requests/delete_user.py`. **')
 
-    # Send Email
-    print('Attempting to send an email')
-    data = requests.send_email(args.endpoint + '/verify',
-                                authentication=auth,
-                                params={'email': data['email']['address']},
-                                headers={'password': data['password']},
-                                verbose=args.verbose)
-
-    # Verify
-    print('Attempting to verify the created user...')
-    data = requests.verify_user(args.endpoint + '/verify',
-                                params={'email': data['email']['address'],
-                                        'token': data['email']['verificationToken']},
-                                headers={'password': data['password']},
-                                verbose=args.verbose)
-
-    if not data:
-        terminate()
-
-    # Update and make PUT request
-    print('Attempting to update the user\'s Facebook access token...')
-
-    data['facebookAccessToken'] = 'BRAND_NEW_FacebookAccessToken'
-    data = requests.update_user(args.endpoint + '/users',
-                                authentication=auth,
-                                params={},
-                                body=data,
-                                headers={'password': data['password']},
-                                verbose=args.verbose)
-
-    if not data:
-        terminate()
-
-    # Ensure we can get the updated user
-    print('Attempting to get the updated user...')
-    data = requests.get_user(args.endpoint + '/users',
-                             authentication=auth,
-                             params={'email': data['email']['address']},
-                             headers={'password': data['password']},
-                             verbose=args.verbose)
-
-    # Update email and make PUT request
-    print('Attempting to update the user\'s email address...')
-
-    existingEmail = data['email']['address']
-    data['email']['address'] = 'newemail@gmail.com'
-    data = requests.update_user(args.endpoint + '/users',
-                                authentication=auth,
-                                params={'email': existingEmail},
-                                body=data,
-                                headers={'password': data['password']},
-                                verbose=args.verbose)
-
-    if not data:
-        terminate()
-
-    # Make DELETE request
-    print('Attempting to delete the user...')
-    data = requests.delete_user(args.endpoint + '/users',
-                                authentication=auth,
-                                params={'email': data['email']['address']},
-                                headers={'password': data['password']},
-                                verbose=args.verbose)
-
-    if not data:
-        print('** NOTE: Deletion failure means this user is still in the DB. **\n'
-              '** NOTE: Delete manually or with `thunder_requests/delete_user.py`. **')
+            print('Aborting...')
+            sys.exit(1)

--- a/scripts/thunder_requests/methods.py
+++ b/scripts/thunder_requests/methods.py
@@ -11,6 +11,7 @@ class Method:
     VERIFY = "VERIFY"
     EMAIL = "EMAIL"
 
+
 def check_response(r, expected, method, verbose=False):
     if r.status_code == expected:
         print('Successfully completed method ' + method)
@@ -89,10 +90,12 @@ def delete_user(endpoint, authentication, params, headers, verbose=False):
 
     return check_response(r, requests.codes.ok, Method.DELETE, verbose)
 
+
+# Attempts to call the verify user endpoint to send a verification email
 def send_email(endpoint, authentication, params, headers, verbose=False):
     try:
         r = requests.post(endpoint, auth=authentication, params=params, headers=headers)
-    except:
+    except requests.exceptions.RequestException:
         print('Unable to connect to the supplied endpoint')
         return False
 

--- a/scripts/user_details.json
+++ b/scripts/user_details.json
@@ -1,6 +1,6 @@
 {
   "email" : {
-    "address": "Testy22@gmail.com"
+    "address": "success@simulator.amazonses.com"
   },
   "password" : "5f4dcc3b5aa765d61d8327deb882cf99",
   "facebookAccessToken" : "facebookAccessToken",


### PR DESCRIPTION
- Restructure `EmailModule` and `EmailService` slightly in order to take in parameters for `endpoint`, `region`, and `fromAddress`.
  - This allows for us to configure the endpoint and region through `config.yaml` so that if they change in the future, we don't have to rebuild. It also means that during integration tests we can use a fake email service, as to not hit the real one.
  - This also allows us to easily configure the `FROM` address through the `config.yaml`
- Some cleanup on the `EmailService` unit tests
- **Much** improved Python `tester.py` script that:
  - Defines functions for test cases and creates a `test_pipeline` to run through the tests in a specific order
  - Attempts to delete the user from the database if a failure occurs at any stage (🎉)