### PR TITLE
Add DynamoDbConfiguration with endpoint and region

### DIFF
--- a/application/src/main/java/com/sanction/thunder/ThunderApplication.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderApplication.java
@@ -27,7 +27,7 @@ public class ThunderApplication extends Application<ThunderConfiguration> {
   public void run(ThunderConfiguration config, Environment env) {
     ThunderComponent component = DaggerThunderComponent.builder()
         .daoModule(new DaoModule())
-        .dynamoDbModule(new DynamoDbModule(config.getDynamoTableName()))
+        .dynamoDbModule(new DynamoDbModule(config.getDynamoConfiguration()))
         .emailModule(new EmailModule(config.getEmailConfiguration()))
         .thunderModule(new ThunderModule(env.metrics(), config))
         .build();

--- a/application/src/main/java/com/sanction/thunder/ThunderComponent.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderComponent.java
@@ -15,8 +15,8 @@ import javax.inject.Singleton;
 @Singleton
 @Component(modules = {DaoModule.class,
                       DynamoDbModule.class,
-                      ThunderModule.class,
-                      EmailModule.class})
+                      EmailModule.class,
+                      ThunderModule.class})
 public interface ThunderComponent {
 
   // Resources

--- a/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
@@ -3,7 +3,9 @@ package com.sanction.thunder;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sanction.thunder.authentication.Key;
 
+import com.sanction.thunder.dynamodb.DynamoDbConfiguration;
 import com.sanction.thunder.email.EmailConfiguration;
+
 import io.dropwizard.Configuration;
 
 import java.util.List;
@@ -14,11 +16,11 @@ class ThunderConfiguration extends Configuration {
 
   @NotNull
   @Valid
-  @JsonProperty("dynamo-table-name")
-  private final String dynamoTableName = null;
+  @JsonProperty("dynamo-db")
+  private final DynamoDbConfiguration dynamoConfiguration = null;
 
-  String getDynamoTableName() {
-    return dynamoTableName;
+  DynamoDbConfiguration getDynamoConfiguration() {
+    return dynamoConfiguration;
   }
 
   @NotNull
@@ -26,7 +28,7 @@ class ThunderConfiguration extends Configuration {
   @JsonProperty("ses")
   private final EmailConfiguration emailConfiguration = null;
 
-  public EmailConfiguration getEmailConfiguration() {
+  EmailConfiguration getEmailConfiguration() {
     return emailConfiguration;
   }
 

--- a/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
@@ -16,7 +16,7 @@ class ThunderConfiguration extends Configuration {
 
   @NotNull
   @Valid
-  @JsonProperty("dynamo-db")
+  @JsonProperty("dynamo")
   private final DynamoDbConfiguration dynamoConfiguration = null;
 
   DynamoDbConfiguration getDynamoConfiguration() {

--- a/application/src/main/java/com/sanction/thunder/dynamodb/DynamoDbConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/dynamodb/DynamoDbConfiguration.java
@@ -1,0 +1,31 @@
+package com.sanction.thunder.dynamodb;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.hibernate.validator.constraints.NotEmpty;
+
+public class DynamoDbConfiguration {
+
+  @NotEmpty
+  @JsonProperty("endpoint")
+  private final String endpoint = null;
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  @NotEmpty
+  @JsonProperty("region")
+  private final String region = null;
+
+  public String getRegion() {
+    return region;
+  }
+
+  @NotEmpty
+  @JsonProperty("table-name")
+  private final String tableName = null;
+
+  public String getTableName() {
+    return tableName;
+  }
+}

--- a/application/src/main/java/com/sanction/thunder/dynamodb/DynamoDbModule.java
+++ b/application/src/main/java/com/sanction/thunder/dynamodb/DynamoDbModule.java
@@ -1,6 +1,6 @@
 package com.sanction.thunder.dynamodb;
 
-import com.amazonaws.regions.Regions;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.document.DynamoDB;
@@ -14,17 +14,26 @@ import javax.inject.Singleton;
 
 @Module
 public class DynamoDbModule {
+  private final String endpoint;
+  private final String region;
   private final String tableName;
 
-  public DynamoDbModule(String tableName) {
-    this.tableName = tableName;
+  /**
+   * Constructs a new DynamoDbModule object.
+   *
+   * @param dynamoConfiguration The configuration to get DynamoDB information from
+   */
+  public DynamoDbModule(DynamoDbConfiguration dynamoConfiguration) {
+    this.endpoint = dynamoConfiguration.getEndpoint();
+    this.region = dynamoConfiguration.getRegion();
+    this.tableName = dynamoConfiguration.getTableName();
   }
 
   @Singleton
   @Provides
   DynamoDB provideDynamoDb() {
     AmazonDynamoDB client = AmazonDynamoDBClientBuilder.standard()
-        .withRegion(Regions.US_EAST_1)
+        .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
         .build();
 
     return new DynamoDB(client);

--- a/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
@@ -3,6 +3,7 @@ package com.sanction.thunder;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 
+import com.sanction.thunder.dynamodb.DynamoDbConfiguration;
 import com.sanction.thunder.dynamodb.DynamoDbHealthCheck;
 import com.sanction.thunder.email.EmailConfiguration;
 import com.sanction.thunder.resources.UserResource;
@@ -34,6 +35,7 @@ public class ThunderApplicationTest {
   private final HealthCheckRegistry healthChecks = mock(HealthCheckRegistry.class);
   private final MetricRegistry metrics = mock(MetricRegistry.class);
   private final ThunderConfiguration config = mock(ThunderConfiguration.class);
+  private final DynamoDbConfiguration dynamoConfig = mock(DynamoDbConfiguration.class);
   private final EmailConfiguration emailConfig = mock(EmailConfiguration.class);
 
   private final ThunderApplication application = new ThunderApplication();
@@ -44,12 +46,16 @@ public class ThunderApplicationTest {
     when(environment.healthChecks()).thenReturn(healthChecks);
     when(environment.metrics()).thenReturn(metrics);
 
+    when(dynamoConfig.getEndpoint()).thenReturn("http://localhost");
+    when(dynamoConfig.getRegion()).thenReturn("us-east-1");
+    when(dynamoConfig.getTableName()).thenReturn("sample-table");
+
     when(emailConfig.getEndpoint()).thenReturn("http://localhost");
     when(emailConfig.getRegion()).thenReturn("us-east-1");
 
     // ThunderConfiguration NotNull fields
     when(config.getApprovedKeys()).thenReturn(new ArrayList<>());
-    when(config.getDynamoTableName()).thenReturn("dynamo-table-name");
+    when(config.getDynamoConfiguration()).thenReturn(dynamoConfig);
     when(config.getEmailConfiguration()).thenReturn(emailConfig);
   }
 

--- a/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
@@ -1,8 +1,6 @@
 package com.sanction.thunder;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-
 import com.google.common.io.Resources;
 import com.sanction.thunder.authentication.Key;
 
@@ -19,7 +17,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public class ThunderConfigurationTest {
-  private final ObjectMapper mapper = Jackson.newObjectMapper(new YAMLFactory());
+  private final ObjectMapper mapper = Jackson.newObjectMapper();
   private final Validator validator = Validators.newValidator();
   private final YamlConfigurationFactory<ThunderConfiguration> factory
       = new YamlConfigurationFactory<>(ThunderConfiguration.class, validator, mapper, "dw");

--- a/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
@@ -3,28 +3,40 @@ package com.sanction.thunder;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
+import com.google.common.io.Resources;
 import com.sanction.thunder.authentication.Key;
 
+import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
-import io.dropwizard.testing.FixtureHelpers;
+import io.dropwizard.jersey.validation.Validators;
 
+import java.io.File;
 import java.util.Arrays;
+import javax.validation.Validator;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 public class ThunderConfigurationTest {
-  private static final ObjectMapper MAPPER = Jackson.newObjectMapper(new YAMLFactory());
+  private final ObjectMapper mapper = Jackson.newObjectMapper(new YAMLFactory());
+  private final Validator validator = Validators.newValidator();
+  private final YamlConfigurationFactory<ThunderConfiguration> factory
+      = new YamlConfigurationFactory<>(ThunderConfiguration.class, validator, mapper, "dw");
 
   @Test
   public void testFromYaml() throws Exception {
-    ThunderConfiguration configuration = MAPPER.readValue(
-        FixtureHelpers.fixture("fixtures/config.yaml"), ThunderConfiguration.class);
+    ThunderConfiguration configuration = factory.build(
+        new File(Resources.getResource("fixtures/config.yaml").toURI()));
 
-    assertEquals("sample-table", configuration.getDynamoTableName());
+    assertEquals("test.dynamodb.com", configuration.getDynamoConfiguration().getEndpoint());
+    assertEquals("test-region-1", configuration.getDynamoConfiguration().getRegion());
+    assertEquals("test-table", configuration.getDynamoConfiguration().getTableName());
+
     assertEquals("test.email.com", configuration.getEmailConfiguration().getEndpoint());
-    assertEquals("test-region", configuration.getEmailConfiguration().getRegion());
+    assertEquals("test-region-2", configuration.getEmailConfiguration().getRegion());
     assertEquals("test@sanctionco.com", configuration.getEmailConfiguration().getFromAddress());
+
     assertEquals(
         Arrays.asList(new Key("test-app", "test-secret")),
         configuration.getApprovedKeys());

--- a/application/src/test/resources/fixtures/config.yaml
+++ b/application/src/test/resources/fixtures/config.yaml
@@ -1,8 +1,11 @@
-dynamo-table-name: sample-table
+dynamo-db:
+  endpoint: test.dynamodb.com
+  region: test-region-1
+  table-name: test-table
 
 ses:
   endpoint: test.email.com
-  region: test-region
+  region: test-region-2
   from-address: test@sanctionco.com
 
 approved-keys:

--- a/application/src/test/resources/fixtures/config.yaml
+++ b/application/src/test/resources/fixtures/config.yaml
@@ -1,4 +1,4 @@
-dynamo-db:
+dynamo:
   endpoint: test.dynamodb.com
   region: test-region-1
   table-name: test-table

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 # Information to access DynamoDB
-dynamo-db:
+dynamo:
   endpoint: dynamodb.us-east-1.amazonaws.com
   region: us-east-1
   table-name: pilot-users-test

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,8 @@
 # Information to access DynamoDB
-dynamo-table-name: pilot-users-test
+dynamo-db:
+  endpoint: dynamodb.us-east-1.amazonaws.com
+  region: us-east-1
+  table-name: pilot-users-test
 
 # Information to access SES
 ses:

--- a/local-config.yaml
+++ b/local-config.yaml
@@ -1,5 +1,5 @@
 # Information to access DynamoDB
-dynamo-db:
+dynamo:
   endpoint: dynamodb.us-east-1.amazonaws.com
   region: us-east-1
   table-name: pilot-users-test

--- a/local-config.yaml
+++ b/local-config.yaml
@@ -1,5 +1,8 @@
 # Information to access DynamoDB
-dynamo-table-name: pilot-users-test
+dynamo-db:
+  endpoint: dynamodb.us-east-1.amazonaws.com
+  region: us-east-1
+  table-name: pilot-users-test
 
 # Information to access SES
 ses:


### PR DESCRIPTION
With this change, we can specify the Dynamo endpoint and region in the config file. This will allow us to easily run integration tests using DynamoDB Local.