### PR TITLE
Fix Mockito deprecation warnings

### DIFF
--- a/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
@@ -21,8 +21,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;

--- a/application/src/test/java/com/sanction/thunder/dao/PilotUsersDaoTest.java
+++ b/application/src/test/java/com/sanction/thunder/dao/PilotUsersDaoTest.java
@@ -21,9 +21,10 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/application/src/test/java/com/sanction/thunder/email/EmailServiceTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/EmailServiceTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/application/src/test/java/com/sanction/thunder/resources/UserResourceTest.java
+++ b/application/src/test/java/com/sanction/thunder/resources/UserResourceTest.java
@@ -13,7 +13,7 @@ import javax.ws.rs.core.Response;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
+++ b/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
@@ -14,8 +14,8 @@ import javax.ws.rs.core.Response;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,7 +65,7 @@ public class VerificationResourceTest {
   @Test
   public void testVerifyUserUpdateUserException() {
     when(usersDao.findByEmail(anyString())).thenReturn(nullDatabaseTokenMockUser);
-    when(usersDao.update(anyString(), anyObject()))
+    when(usersDao.update(anyString(), any(PilotUser.class)))
         .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
 
     Response response = resource.verifyUser(key, "test@test.com", "password");
@@ -76,7 +76,7 @@ public class VerificationResourceTest {
   @Test
   public void testVerifyUserSendEmailException() {
     when(usersDao.findByEmail(anyString())).thenReturn(nullDatabaseTokenMockUser);
-    when(usersDao.update(anyString(), anyObject()))
+    when(usersDao.update(anyString(), any(PilotUser.class)))
         .thenReturn(unverifiedMockUser);
     when(emailService.sendEmail(unverifiedMockUser.getEmail(),
         "Account Verification",
@@ -91,9 +91,9 @@ public class VerificationResourceTest {
   @Test
   public void testVerifyUserSuccess() {
     when(usersDao.findByEmail(anyString())).thenReturn(nullDatabaseTokenMockUser);
-    when(usersDao.update(anyString(), anyObject()))
+    when(usersDao.update(anyString(), any(PilotUser.class)))
         .thenReturn(unverifiedMockUser);
-    when(emailService.sendEmail(anyObject(),
+    when(emailService.sendEmail(any(Email.class),
         anyString(),
         anyString(),
         anyString())).thenReturn(true);


### PR DESCRIPTION
Addresses #41.

- Replace deprecated `Matchers` with `ArgumentMatchers`
- Replace `anyObject()` with `any(<T> class)`