### PR TITLE
Add option for email verification to respond with HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,20 @@ Thunder is part of the backend for [Pilot](https://github.com/RohanNagar/pilot-o
   the user must be included as a header parameter. The user in the database will be updated to
   include a unique verification token that is sent along with the email.
 
-- `GET` `/verify?email=sampleuser@sanctionco.com&token=12345`
+- `GET` `/verify?email=sampleuser@sanctionco.com&token=12345&response_type=json`
 
   A GET request sent to the verify endpoint is used to verify a user email. The endpoint is called
   with an email address and a verification token that has been sent to the user via email.
   Upon verification, the user object in the database will be updated to indicate that the email address
-  is verified.
+  is verified. The `response_type` query parameter determines if the method should return either an HTML
+  success page or a JSON user response. If HTML is specified, the URL will redirect to `/verify/success`.
+  The default `response_type` is JSON.
+
+ - `GET` `/verify/success`
+
+  This GET request will return an HTML success page that is shown after a user successfully verifies
+  their account. `GET /verify` will redirect to this URL if the `response_type` query parameter
+  is set to `html`.
 
 ## Client Library Usage
 

--- a/api/src/main/java/com/sanction/thunder/models/ResponseType.java
+++ b/api/src/main/java/com/sanction/thunder/models/ResponseType.java
@@ -1,0 +1,34 @@
+package com.sanction.thunder.models;
+
+public enum ResponseType {
+  JSON("json"),
+  HTML("html");
+
+  private final String text;
+
+  ResponseType(String text) {
+    this.text = text;
+  }
+
+  /**
+   * Provides a ResponseType representation of a given string.
+   *
+   * @param text The string to parse into a ResponseType.
+   * @return The corresponding ResponseType representation.
+   */
+  public static ResponseType fromString(String text) {
+    for (ResponseType type : ResponseType.values()) {
+      if (type.text.equalsIgnoreCase(text)) {
+        return type;
+      }
+    }
+
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return this.text;
+  }
+}
+

--- a/api/src/test/java/com/sanction/thunder/models/ResponseTypeTest.java
+++ b/api/src/test/java/com/sanction/thunder/models/ResponseTypeTest.java
@@ -1,0 +1,26 @@
+package com.sanction.thunder.models;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ResponseTypeTest {
+
+  @Test
+  public void testJsonFromString() {
+    assertEquals(ResponseType.JSON, ResponseType.fromString("json"));
+    assertEquals("json", ResponseType.JSON.toString());
+  }
+
+  @Test
+  public void testHtmlFromString() {
+    assertEquals(ResponseType.HTML, ResponseType.fromString("html"));
+    assertEquals("html", ResponseType.HTML.toString());
+  }
+
+  @Test
+  public void testNullResponseTypeFromString() {
+    assertNull(ResponseType.fromString("unknown"));
+  }
+}

--- a/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
@@ -156,6 +156,7 @@ public class VerificationResource {
    *
    * @param email The email to verify in the database.
    * @param token The verification token associated with the user.
+   * @param responseType The type of object to respond with. Either JSON or HTML.
    * @return A response status and message.
    */
   @GET

--- a/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
@@ -8,6 +8,7 @@ import com.sanction.thunder.dao.UsersDao;
 import com.sanction.thunder.email.EmailService;
 import com.sanction.thunder.models.Email;
 import com.sanction.thunder.models.PilotUser;
+import com.sanction.thunder.models.ResponseType;
 
 import io.dropwizard.auth.Auth;
 
@@ -16,6 +17,7 @@ import java.util.UUID;
 
 import javax.inject.Inject;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
@@ -156,7 +158,9 @@ public class VerificationResource {
    */
   @GET
   public Response verifyEmail(@QueryParam("email") String email,
-                              @QueryParam("token") String token) {
+                              @QueryParam("token") String token,
+                              @QueryParam("response_type") @DefaultValue("html")
+                                  ResponseType responseType) {
     verifyEmailRequests.mark();
 
     if (email == null || email.isEmpty()) {
@@ -211,7 +215,21 @@ public class VerificationResource {
     }
 
     LOG.info("Successfully verified email {}.", email);
+    if (responseType.equals(ResponseType.JSON)) {
+      LOG.info("Returning JSON in the response.");
+      return Response.ok(updatedUser).build();
+    }
+
+    // TODO redirect to /verify/success since ResponseType is HTML
+    LOG.info("Redirecting to /verify/success in order to return HTML.");
     return Response.ok(updatedUser).build();
+  }
+
+  @GET
+  @Path("/success")
+  @Produces(MediaType.TEXT_HTML)
+  public Response getSuccessHtml() {
+    return Response.ok("<body>Success</body>").build();
   }
 
   /**

--- a/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
@@ -129,14 +129,14 @@ public class VerificationResource {
         new StringJoiner("\n")
           .add("<h1> Welcome to Pilot! </h1>")
           .add("<p> Click the below link to verify your account. </p>")
-          .add(String.format("<a href=\"http://thunder.sanctionco.com/verify?email=%s&token=%s\">"
-            + "Click here to verify your account!</a>",
+          .add(String.format("<a href=\"http://thunder.sanctionco.com/verify"
+            + "?email=%s&token=%s&response_type=html\">Click here to verify your account!</a>",
             result.getEmail().getAddress(),
             token))
           .toString(),
         new StringJoiner("\n")
           .add("Visit the below address to verify your account.")
-          .add(String.format("thunder.sanctionco.com/verify?email=%s&token=%s",
+          .add(String.format("http://thunder.sanctionco.com/verify?email=%s&token=%s&response_type=html",
             result.getEmail().getAddress(),
             token))
           .toString());
@@ -161,7 +161,7 @@ public class VerificationResource {
   @GET
   public Response verifyEmail(@QueryParam("email") String email,
                               @QueryParam("token") String token,
-                              @QueryParam("response_type") @DefaultValue("html")
+                              @QueryParam("response_type") @DefaultValue("json")
                                   ResponseType responseType) {
     verifyEmailRequests.mark();
 

--- a/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
@@ -12,6 +12,7 @@ import com.sanction.thunder.models.ResponseType;
 
 import io.dropwizard.auth.Auth;
 
+import java.net.URI;
 import java.util.StringJoiner;
 import java.util.UUID;
 
@@ -26,6 +27,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -220,9 +222,9 @@ public class VerificationResource {
       return Response.ok(updatedUser).build();
     }
 
-    // TODO redirect to /verify/success since ResponseType is HTML
     LOG.info("Redirecting to /verify/success in order to return HTML.");
-    return Response.ok(updatedUser).build();
+    URI uri = UriBuilder.fromUri("/verify/success").build();
+    return Response.seeOther(uri).build();
   }
 
   /**

--- a/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
@@ -225,11 +225,24 @@ public class VerificationResource {
     return Response.ok(updatedUser).build();
   }
 
+  /**
+   * Returns HTML to display as a success page after user verification.
+   *
+   * @return A Response containing the HTML to display to the user.
+   */
   @GET
   @Path("/success")
   @Produces(MediaType.TEXT_HTML)
   public Response getSuccessHtml() {
-    return Response.ok("<body>Success</body>").build();
+    String html = new StringJoiner("\n")
+        .add("<div class=\"alert alert-success\">")
+        .add("<center><strong>Success!</strong></br>Your account has been verified.</center>")
+        .add("</div>")
+        .add("<link rel=\"stylesheet\""
+            + " href=\"https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css\" />")
+        .toString();
+
+    return Response.ok(html).build();
   }
 
   /**

--- a/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
+++ b/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
@@ -194,4 +194,20 @@ public class VerificationResourceTest {
     assertEquals(response.getStatusInfo(), Response.Status.SEE_OTHER);
     assertEquals(UriBuilder.fromUri("/verify/success").build(), result);
   }
+
+  /* HTML Success Tests */
+  @Test
+  public void testGetSuccessHtml() {
+    String expected = "<div class=\"alert alert-success\">\n"
+        + "<center><strong>Success!</strong></br>Your account has been verified.</center>\n"
+        + "</div>\n"
+        + "<link rel=\"stylesheet\""
+        + " href=\"https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css\" />";
+
+    Response response = resource.getSuccessHtml();
+    String result = (String) response.getEntity();
+
+    assertEquals(Response.Status.OK, response.getStatusInfo());
+    assertEquals(expected, result);
+  }
 }

--- a/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
+++ b/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
@@ -9,8 +9,12 @@ import com.sanction.thunder.dao.UsersDao;
 import com.sanction.thunder.email.EmailService;
 import com.sanction.thunder.models.Email;
 import com.sanction.thunder.models.PilotUser;
+import com.sanction.thunder.models.ResponseType;
 
+import java.net.URI;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -108,14 +112,14 @@ public class VerificationResourceTest {
   /* Verify Email Tests */
   @Test
   public void testVerifyEmailWithNullEmail() {
-    Response response = resource.verifyEmail(null, "verificationToken");
+    Response response = resource.verifyEmail(null, "verificationToken", ResponseType.JSON);
 
     assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
   }
 
   @Test
   public void testVerifyEmailWithNullToken() {
-    Response response = resource.verifyEmail("test@test.com", null);
+    Response response = resource.verifyEmail("test@test.com", null, ResponseType.JSON);
 
     assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
   }
@@ -125,7 +129,8 @@ public class VerificationResourceTest {
     when(usersDao.findByEmail(anyString()))
         .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
 
-    Response response = resource.verifyEmail("test@test.com", "verificationToken");
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.JSON);
 
     assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
   }
@@ -134,7 +139,8 @@ public class VerificationResourceTest {
   public void testVerifyEmailWithNullDatabaseToken() {
     when(usersDao.findByEmail(anyString())).thenReturn(nullDatabaseTokenMockUser);
 
-    Response response = resource.verifyEmail("test@test.com", "verificationToken");
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.JSON);
 
     assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
   }
@@ -143,7 +149,8 @@ public class VerificationResourceTest {
   public void testVerifyEmailWithMismatchedToken() {
     when(usersDao.findByEmail(anyString())).thenReturn(mismatchedTokenMockUser);
 
-    Response response = resource.verifyEmail("test@test.com", "verificationToken");
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.JSON);
 
     assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
   }
@@ -154,7 +161,8 @@ public class VerificationResourceTest {
     when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
         .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
 
-    Response response = resource.verifyEmail("test@test.com", "verificationToken");
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.JSON);
 
     assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
   }
@@ -165,10 +173,25 @@ public class VerificationResourceTest {
     when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
         .thenReturn(verifiedMockUser);
 
-    Response response = resource.verifyEmail("test@test.com", "verificationToken");
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.JSON);
     PilotUser result = (PilotUser) response.getEntity();
 
     assertEquals(response.getStatusInfo(), Response.Status.OK);
     assertEquals(verifiedMockUser, result);
+  }
+
+  @Test
+  public void testVerifyEmailWithHtmlResponse() {
+    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
+    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
+        .thenReturn(verifiedMockUser);
+
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.HTML);
+    URI result = response.getLocation();
+
+    assertEquals(response.getStatusInfo(), Response.Status.SEE_OTHER);
+    assertEquals(UriBuilder.fromUri("/verify/success").build(), result);
   }
 }

--- a/client/src/main/java/com/sanction/thunder/ThunderClient.java
+++ b/client/src/main/java/com/sanction/thunder/ThunderClient.java
@@ -2,6 +2,8 @@ package com.sanction.thunder;
 
 import com.sanction.thunder.models.PilotUser;
 
+import com.sanction.thunder.models.ResponseType;
+import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
@@ -70,6 +72,7 @@ public interface ThunderClient {
 
   /**
    * Verifies an already created PilotUser with the given email.
+   * Use this method to get a PilotUser back as the returned object.
    *
    * @param email The email address of the user to verify.
    * @param token The verification token of the user to verify.
@@ -78,4 +81,21 @@ public interface ThunderClient {
   @GET("verify")
   Call<PilotUser> verifyUser(@Query("email") String email,
                              @Query("token") String token);
+
+  /**
+   * Verifies an already created PilotUser with the given email.
+   * Use this method to get HTML back as the returned object.
+   * If you want to get the verified PilotUser object back, use the
+   * verifyUser() method without the responseType parameter.
+   *
+   * @param email The email address of the user to verify.
+   * @param token The verification token of the user to verify.
+   * @param responseType The type of response to receive (HTML or JSON).
+   * @return The response in string form. This will be an HTML string if
+   *            responseType was set to HTML, or a JSON string if responseType was set to JSON.
+   */
+  @GET("verify")
+  Call<ResponseBody> verifyUser(@Query("email") String email,
+                                @Query("token") String token,
+                                @Query("response_type") ResponseType responseType);
 }


### PR DESCRIPTION
### This PR addresses:

<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists -->
Addresses #28.

- Allow the option of returning HTML when the user email is verified
- Use HTML option when building the email in `sendEmail()`
- Add option to get HTML from the Java client
- Update tests and documentation

### I have verified that:

<!-- Ensure all of these boxes are checked -->
- [x] All related unit tests have been updated/created
- [x] Integration tests are passing

### Additional Notes

<!-- Put any other additional notes here for reviewers -->
Changes to the JavaScript library will come shortly after