### PR TITLE
Improved UserTests, fix configuration syntax

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ package:
     paths:
       - .m2/repository
 
-# Build and push Docker test image
+# Build and push Docker edge image
 docker:
   stage: publish
   image: docker:latest
@@ -29,8 +29,8 @@ docker:
   before_script:
     - echo $DOCKER_PASSWORD | docker login -u rohannagar --password-stdin
   script:
-    - docker build -t rohannagar/thunder:test .
-    - docker push rohannagar/thunder:test
+    - docker build -t rohannagar/thunder:edge .
+    - docker push rohannagar/thunder:edge
   only:
     refs:
       - master
@@ -50,4 +50,3 @@ docker-deploy:
     - docker push $IMAGE_TAG
   only:
     - tags
-

--- a/api/src/main/java/com/sanction/thunder/models/User.java
+++ b/api/src/main/java/com/sanction/thunder/models/User.java
@@ -3,6 +3,7 @@ package com.sanction.thunder.models;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
@@ -18,6 +19,7 @@ public class User {
    * @param email The email of the user.
    * @param password The salted and hashed password of the user.
    * @param properties A map of additional user properties.
+   *                   If null, will be converted to an empty Map.
    */
   @JsonCreator
   public User(@JsonProperty("email") Email email,
@@ -25,7 +27,7 @@ public class User {
               @JsonProperty("properties") Map<String, Object> properties) {
     this.email = email;
     this.password = password;
-    this.properties = properties;
+    this.properties = properties == null ? Collections.emptyMap() : properties;
   }
 
   public Email getEmail() {
@@ -51,12 +53,14 @@ public class User {
     }
 
     User other = (User) obj;
-    return Objects.equals(this.email, other.email);
+    return Objects.equals(this.email, other.email)
+        && Objects.equals(this.password, other.password)
+        && Objects.equals(this.properties, other.properties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(this.email);
+    return Objects.hash(this.email, this.password, this.properties);
   }
 
   @Override

--- a/api/src/test/java/com/sanction/thunder/models/UserTest.java
+++ b/api/src/test/java/com/sanction/thunder/models/UserTest.java
@@ -5,9 +5,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.testing.FixtureHelpers;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.StringJoiner;
+import java.util.TreeMap;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -17,64 +21,97 @@ import static org.junit.Assert.assertTrue;
 
 public class UserTest {
   private static final ObjectMapper MAPPER = Jackson.newObjectMapper();
+  private static final Email EMAIL = new Email("test@test.com", true, "hashToken");
+  private static final String PASSWORD = "12345";
+  private static final Map<String, Object> MULTIPLE_PROPERTY_MAP = new TreeMap<>();
 
-  private final Email email = new Email("test@test.com", true, "hashToken");
-  private final Email emailTwo = new Email("testTwo@test.com", true, "hashTokenTwo");
+  private final User emptyPropertiesUser = new User(EMAIL, PASSWORD, Collections.emptyMap());
+  private final User multiplePropertiesUser = new User(EMAIL, PASSWORD, MULTIPLE_PROPERTY_MAP);
 
-  private final User user = new User(
-      email, "12345",
-      Collections.singletonMap("facebookAccessToken", "fb"));
-
-  @Test
-  public void testToJson() throws Exception {
-    String expected = MAPPER.writeValueAsString(
-        MAPPER.readValue(FixtureHelpers.fixture("fixtures/user.json"), User.class));
-
-    assertEquals(expected, MAPPER.writeValueAsString(user));
+  /**
+   * Set up the class by adding properties to the MULTIPLE_PROPERTY_MAP.
+   */
+  @BeforeClass
+  public static void setup() {
+    MULTIPLE_PROPERTY_MAP.put("customString", "value");
+    MULTIPLE_PROPERTY_MAP.put("customInt", 1);
+    MULTIPLE_PROPERTY_MAP.put("customDouble", 1.2);
+    MULTIPLE_PROPERTY_MAP.put("customBoolean", true);
+    MULTIPLE_PROPERTY_MAP.put("customList", Arrays.asList("hello", "world"));
   }
 
   @Test
-  public void testFromJson() throws Exception {
-    User fromJson = MAPPER.readValue(
-        FixtureHelpers.fixture("fixtures/user.json"), User.class);
+  public void testToJsonNoProperties() throws Exception {
+    String expected = MAPPER.writeValueAsString(MAPPER.readValue(
+        FixtureHelpers.fixture("fixtures/no_properties_user.json"), User.class));
 
-    assertEquals(user, fromJson);
+    assertEquals(expected, MAPPER.writeValueAsString(emptyPropertiesUser));
+  }
+
+  @Test
+  public void testFromJsonNoProperties() throws Exception {
+    User fromJson = MAPPER.readValue(
+        FixtureHelpers.fixture("fixtures/no_properties_user.json"), User.class);
+
+    assertEquals(emptyPropertiesUser, fromJson);
+  }
+
+  @Test
+  public void testToJsonEmptyProperties() throws Exception {
+    String expected = MAPPER.writeValueAsString(MAPPER.readValue(
+        FixtureHelpers.fixture("fixtures/empty_properties_user.json"),User.class));
+
+    assertEquals(expected, MAPPER.writeValueAsString(emptyPropertiesUser));
+  }
+
+  @Test
+  public void testFromJsonEmptyProperties() throws Exception {
+    User fromJson = MAPPER.readValue(
+        FixtureHelpers.fixture("fixtures/empty_properties_user.json"), User.class);
+
+    assertEquals(emptyPropertiesUser, fromJson);
+  }
+
+  @Test
+  public void testToJsonMultipleProperties() throws Exception {
+    String expected = MAPPER.writeValueAsString(MAPPER.readValue(
+        FixtureHelpers.fixture("fixtures/multiple_properties_user.json"), User.class));
+
+    assertEquals(expected, MAPPER.writeValueAsString(multiplePropertiesUser));
+  }
+
+  @Test
+  public void testFromJsonMultipleProperties() throws Exception {
+    User fromJson = MAPPER.readValue(
+        FixtureHelpers.fixture("fixtures/multiple_properties_user.json"), User.class);
+
+    assertEquals(multiplePropertiesUser, fromJson);
   }
 
   @Test
   public void testEqualsSameObject() {
-    assertTrue(user.equals(user));
+    assertTrue(multiplePropertiesUser.equals(multiplePropertiesUser));
   }
 
   @Test
   public void testEqualsDifferentObject() {
     Object objectTwo = new Object();
 
-    assertFalse(user.equals(objectTwo));
+    assertFalse(multiplePropertiesUser.equals(objectTwo));
   }
 
   @Test
   public void testHashCodeSame() {
-    User userOne = new User(
-        email, "12345",
-        Collections.singletonMap("facebookAccessToken", "fb"));
-
-    User userTwo = new User(
-        email, "54321",
-        Collections.singletonMap("facebookAccessToken", "fb"));
+    User userOne = new User(EMAIL, PASSWORD, Collections.singletonMap("customKey", 1));
+    User userTwo = new User(EMAIL, PASSWORD, Collections.singletonMap("customKey", 1));
 
     assertEquals(userOne.hashCode(), userTwo.hashCode());
   }
 
   @Test
   public void testHashCodeDifferent() {
-    User userOne = new User(
-        email, "12345",
-        Collections.singletonMap("facebookAccessToken", "fb"));
-
-    User userTwo = new User(
-        emailTwo, "12345",
-        Collections.singletonMap("facebookAccessToken", "fb"));
+    User userOne = new User(EMAIL, PASSWORD, Collections.singletonMap("customKey", 1));
+    User userTwo = new User(EMAIL, PASSWORD, Collections.singletonMap("customKey", 2));
 
     assertNotEquals(userOne.hashCode(), userTwo.hashCode());
   }
@@ -82,12 +119,11 @@ public class UserTest {
   @Test
   public void testToString() {
     String expected = new StringJoiner(", ", "User [", "]")
-            .add(String.format("email=%s", email))
-            .add(String.format("password=%s", "12345"))
-            .add(String.format("properties=%s",
-                Collections.singletonMap("facebookAccessToken", "fb")))
+            .add(String.format("email=%s", EMAIL))
+            .add(String.format("password=%s", PASSWORD))
+            .add(String.format("properties=%s", MULTIPLE_PROPERTY_MAP))
             .toString();
 
-    assertEquals(expected, user.toString());
+    assertEquals(expected, multiplePropertiesUser.toString());
   }
 }

--- a/api/src/test/resources/fixtures/empty_properties_user.json
+++ b/api/src/test/resources/fixtures/empty_properties_user.json
@@ -5,7 +5,5 @@
     "verificationToken" : "hashToken"
   },
   "password" : "12345",
-  "properties" : {
-    "facebookAccessToken" : "fb"
-  }
+  "properties" : {}
 }

--- a/api/src/test/resources/fixtures/multiple_properties_user.json
+++ b/api/src/test/resources/fixtures/multiple_properties_user.json
@@ -1,0 +1,15 @@
+{
+  "email" : {
+    "address" : "test@test.com",
+    "verified" : "true",
+    "verificationToken" : "hashToken"
+  },
+  "password" : "12345",
+  "properties" : {
+    "customBoolean" : true,
+    "customDouble" : 1.2,
+    "customInt" : 1,
+    "customList" : ["hello", "world"],
+    "customString" : "value"
+  }
+}

--- a/api/src/test/resources/fixtures/no_properties_user.json
+++ b/api/src/test/resources/fixtures/no_properties_user.json
@@ -1,0 +1,8 @@
+{
+  "email" : {
+    "address" : "test@test.com",
+    "verified" : "true",
+    "verificationToken" : "hashToken"
+  },
+  "password" : "12345"
+}

--- a/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
@@ -34,7 +34,7 @@ class ThunderConfiguration extends Configuration {
 
   @NotNull
   @Valid
-  @JsonProperty("approved-keys")
+  @JsonProperty("approvedKeys")
   private final List<Key> approvedKeys = null;
 
   List<Key> getApprovedKeys() {

--- a/application/src/main/java/com/sanction/thunder/dynamodb/DynamoDbConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/dynamodb/DynamoDbConfiguration.java
@@ -22,7 +22,7 @@ public class DynamoDbConfiguration {
   }
 
   @NotEmpty
-  @JsonProperty("table-name")
+  @JsonProperty("tableName")
   private final String tableName = null;
 
   public String getTableName() {

--- a/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
@@ -22,7 +22,7 @@ public class EmailConfiguration {
   }
 
   @NotEmpty
-  @JsonProperty("from-address")
+  @JsonProperty("fromAddress")
   private final String fromAddress = null;
 
   public String getFromAddress() {

--- a/application/src/test/resources/fixtures/config.yaml
+++ b/application/src/test/resources/fixtures/config.yaml
@@ -1,13 +1,13 @@
 dynamo:
   endpoint: test.dynamodb.com
   region: test-region-1
-  table-name: test-table
+  tableName: test-table
 
 ses:
   endpoint: test.email.com
   region: test-region-2
-  from-address: test@sanctionco.com
+  fromAddress: test@sanctionco.com
 
-approved-keys:
+approvedKeys:
   - application: test-app
     secret: test-secret

--- a/config/cloud-dev-config.yaml
+++ b/config/cloud-dev-config.yaml
@@ -2,16 +2,16 @@
 dynamo:
   endpoint: dynamodb.us-east-1.amazonaws.com
   region: us-east-1
-  table-name: pilot-users-test
+  tableName: pilot-users-test
 
 # Information to access SES
 ses:
   endpoint: email.us-east-1.amazonaws.com
   region: us-east-1
-  from-address: noreply@sanctionco.com
+  fromAddress: noreply@sanctionco.com
 
 # Approved Application Authentication Credentials
-approved-keys:
+approvedKeys:
   - application: application
     secret: secret
 

--- a/config/local-dev-config.yaml
+++ b/config/local-dev-config.yaml
@@ -2,16 +2,16 @@
 dynamo:
   endpoint: http://localhost:4567
   region: us-east-1
-  table-name: pilot-users-test
+  tableName: pilot-users-test
 
 # Information to access SES
 ses:
   endpoint: http://localhost:9001
   region: us-east-1
-  from-address: noreply@sanctionco.com
+  fromAddress: noreply@sanctionco.com
 
 # Approved Application Authentication Credentials
-approved-keys:
+approvedKeys:
   - application: application
     secret: secret
 

--- a/config/prod-config.yaml
+++ b/config/prod-config.yaml
@@ -2,16 +2,16 @@
 dynamo:
   endpoint: dynamodb.us-east-1.amazonaws.com
   region: us-east-1
-  table-name: pilot-users-test
+  tableName: pilot-users-test
 
 # Information to access SES
 ses:
   endpoint: email.us-east-1.amazonaws.com
   region: us-east-1
-  from-address: noreply@sanctionco.com
+  fromAddress: noreply@sanctionco.com
 
 # Approved Application Authentication Credentials
-approved-keys:
+approvedKeys:
   - application: lightning
     secret:
   - application: pilot

--- a/config/test-config.yaml
+++ b/config/test-config.yaml
@@ -2,16 +2,16 @@
 dynamo:
   endpoint: http://localhost:4567
   region: us-east-1
-  table-name: pilot-users-test
+  tableName: pilot-users-test
 
 # Information to access SES
 ses:
   endpoint: http://localhost:9001
   region: us-east-1
-  from-address: noreply@sanctionco.com
+  fromAddress: noreply@sanctionco.com
 
 # Approved Application Authentication Credentials
-approved-keys:
+approvedKeys:
   - application: application
     secret: secret
 


### PR DESCRIPTION
### This PR addresses:

<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists -->
3 issues in one!

- Address #144: The Docker image that is built on every commit from master is now tagged as `edge`. See the `.gitlab-ci.yml` to see the change.
- Address #145: The `config.yaml` values that used to have a hyphen (-) now use camel-case, which is Dropwizard convention.
- Address #142: Better UserTest, including verifying serialization/deserialization for a User with no properties, empty properties, and multiple properties.
- Update `User` `equals()` and `hashCode()` to include the `password` and `properties` fields as well.

### I have verified that:

<!-- Ensure all of these boxes are checked -->
- [x] All related unit tests have been updated/created
- [x] Integration tests are passing

### Additional Notes

<!-- Put any other additional notes here for reviewers -->
This is a breaking change with configuration files, FYI.