### PR TITLE
Custom loading of HTML success and verification pages

### DIFF
--- a/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
@@ -28,4 +28,28 @@ public class EmailConfiguration {
   public String getFromAddress() {
     return fromAddress;
   }
+
+  @NotEmpty
+  @JsonProperty("success-html")
+  private final String successHtmlPath = null;
+
+  public String getSuccessHtmlPath() {
+    return successHtmlPath;
+  }
+
+  @NotEmpty
+  @JsonProperty("verification-html")
+  private final String verificationHtmlPath = null;
+
+  public String getVerificationHtmlPath() {
+    return verificationHtmlPath;
+  }
+
+  @NotEmpty
+  @JsonProperty("verification-text")
+  private final String verificationTextPath = null;
+
+  public String getVerificationTextPath() {
+    return verificationTextPath;
+  }
 }

--- a/application/src/main/java/com/sanction/thunder/email/EmailException.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailException.java
@@ -1,0 +1,33 @@
+package com.sanction.thunder.email;
+
+public class EmailException extends RuntimeException {
+
+  /**
+   * Constructs a new EmailException.
+   *
+   * @param message The message for the exception.
+   */
+  public EmailException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new EmailException.
+   *
+   * @param message The message for the exception.
+   * @param cause The cause of the exception.
+   */
+  public EmailException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Constructs a new EmailException.
+   *
+   * @param cause The cause of the exception.
+   */
+  public EmailException(Throwable cause) {
+    super(cause);
+  }
+
+}

--- a/application/src/main/java/com/sanction/thunder/email/EmailModule.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailModule.java
@@ -3,9 +3,17 @@ package com.sanction.thunder.email;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
 import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder;
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
 import dagger.Module;
 import dagger.Provides;
 
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 @Module
@@ -13,6 +21,9 @@ public class EmailModule {
   private final String endpoint;
   private final String region;
   private final String fromAddress;
+  private final String successHtmlPath;
+  private final String verificationHtmlPath;
+  private final String verificationTextPath;
 
   /**
    * Constructs a new EmailModule object.
@@ -23,6 +34,9 @@ public class EmailModule {
     this.endpoint = emailConfiguration.getEndpoint();
     this.region = emailConfiguration.getRegion();
     this.fromAddress = emailConfiguration.getFromAddress();
+    this.successHtmlPath = emailConfiguration.getSuccessHtmlPath();
+    this.verificationHtmlPath = emailConfiguration.getVerificationHtmlPath();
+    this.verificationTextPath = emailConfiguration.getVerificationTextPath();
   }
 
   @Singleton
@@ -39,4 +53,42 @@ public class EmailModule {
     return new EmailService(emailService, fromAddress);
   }
 
+  @Singleton
+  @Provides
+  @Named("successHtml")
+  String provideSuccessHtml() {
+    try {
+      return Resources.toString(Resources.getResource(successHtmlPath), Charsets.UTF_8);
+    } catch (IOException e) {
+      throw new EmailException("Error reading file from path: " + successHtmlPath, e);
+    } catch (Exception e) {
+      throw new EmailException("Error while providing success HTML", e);
+    }
+  }
+
+  @Singleton
+  @Provides
+  @Named("verificationHtml")
+  String provideVerificationHtml() {
+    try {
+      return Resources.toString(Resources.getResource(verificationHtmlPath), Charsets.UTF_8);
+    } catch (IOException e) {
+      throw new EmailException("Error reading file from path: " + verificationHtmlPath, e);
+    } catch (Exception e) {
+      throw new EmailException("Error while providing verification HTML", e);
+    }
+  }
+
+  @Singleton
+  @Provides
+  @Named("verificationText")
+  String provideVerificationText() {
+    try {
+      return Resources.toString(Resources.getResource(verificationTextPath), Charsets.UTF_8);
+    } catch (IOException e) {
+      throw new EmailException("Error reading file from path:" + verificationTextPath, e);
+    } catch (Exception e) {
+      throw new EmailException("Error while providing verification text", e);
+    }
+  }
 }

--- a/application/src/main/resources/success.html
+++ b/application/src/main/resources/success.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<div class="alert alert-success">
+    <div align="center"><strong>Success!</strong><br>Your account has been verified.</div>
+</div>
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
+</html>

--- a/application/src/main/resources/verification.html
+++ b/application/src/main/resources/verification.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<h1> Welcome to Pilot! </h1>
+<p> Click the below link to verify your account. </p>
+<a href="http://thunder.sanctionco.com/verify?email=%s&token=%s&response_type=html">Click here to verify your account!</a>
+</html>

--- a/application/src/main/resources/verification.txt
+++ b/application/src/main/resources/verification.txt
@@ -1,0 +1,2 @@
+Visit the below address to verify your account.
+http://thunder.sanctionco.com/verify?email=%s&token=%s&response_type=html

--- a/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
@@ -56,6 +56,9 @@ public class ThunderApplicationTest {
 
     when(emailConfig.getEndpoint()).thenReturn("http://localhost");
     when(emailConfig.getRegion()).thenReturn("us-east-1");
+    when(emailConfig.getSuccessHtmlPath()).thenReturn("fixtures/success-fixture.html");
+    when(emailConfig.getVerificationHtmlPath()).thenReturn("fixtures/verification-fixture.html");
+    when(emailConfig.getVerificationTextPath()).thenReturn("fixtures/verification-fixture.txt");
 
     // ThunderConfiguration NotNull fields
     when(config.getApprovedKeys()).thenReturn(new ArrayList<>());

--- a/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
@@ -34,9 +34,14 @@ public class ThunderConfigurationTest {
     assertEquals("test.email.com", configuration.getEmailConfiguration().getEndpoint());
     assertEquals("test-region-2", configuration.getEmailConfiguration().getRegion());
     assertEquals("test@sanctionco.com", configuration.getEmailConfiguration().getFromAddress());
+    assertEquals("fixtures/success-fixture.html",
+        configuration.getEmailConfiguration().getSuccessHtmlPath());
+    assertEquals("fixtures/verification-fixture.html",
+        configuration.getEmailConfiguration().getVerificationHtmlPath());
+    assertEquals("fixtures/verification-fixture.txt",
+        configuration.getEmailConfiguration().getVerificationTextPath());
 
-    assertEquals(
-        Collections.singletonList(new Key("test-app", "test-secret")),
-        configuration.getApprovedKeys());
+    assertEquals(Collections.singletonList(new Key("test-app", "test-secret")),
+                 configuration.getApprovedKeys());
   }
 }

--- a/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
+++ b/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
@@ -29,6 +29,9 @@ public class VerificationResourceTest {
   private final MetricRegistry metrics = new MetricRegistry();
   private final Key key = mock(Key.class);
   private final EmailService emailService = mock(EmailService.class);
+  private final String successHtmlPath = "fixtures/success-fixture.html";
+  private final String verificationHtmlPath = "fixtures/verification-fixture.html";
+  private final String verificationTextPath = "fixtures/verification-fixture.text";
 
   private final User unverifiedMockUser =
       new User(new Email("test@test.com", false, "verificationToken"),
@@ -44,7 +47,8 @@ public class VerificationResourceTest {
           "password", Collections.emptyMap());
 
   private final VerificationResource resource =
-      new VerificationResource(usersDao, metrics, emailService);
+      new VerificationResource(usersDao, metrics, emailService, successHtmlPath,
+          verificationHtmlPath, verificationTextPath);
 
   /* Verify User Tests */
   @Test
@@ -203,11 +207,7 @@ public class VerificationResourceTest {
   /* HTML Success Tests */
   @Test
   public void testGetSuccessHtml() {
-    String expected = "<div class=\"alert alert-success\">\n"
-        + "<center><strong>Success!</strong></br>Your account has been verified.</center>\n"
-        + "</div>\n"
-        + "<link rel=\"stylesheet\""
-        + " href=\"https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css\" />";
+    String expected = "fixtures/success-fixture.html";
 
     Response response = resource.getSuccessHtml();
     String result = (String) response.getEntity();

--- a/application/src/test/resources/fixtures/config.yaml
+++ b/application/src/test/resources/fixtures/config.yaml
@@ -7,6 +7,9 @@ ses:
   endpoint: test.email.com
   region: test-region-2
   from-address: test@sanctionco.com
+  success-html: fixtures/success-fixture.html
+  verification-html: fixtures/verification-fixture.html
+  verification-text: fixtures/verification-fixture.txt
 
 approved-keys:
   - application: test-app

--- a/application/src/test/resources/fixtures/success-fixture.html
+++ b/application/src/test/resources/fixtures/success-fixture.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/application/src/test/resources/fixtures/verification-fixture.html
+++ b/application/src/test/resources/fixtures/verification-fixture.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/config/cloud-dev-config.yaml
+++ b/config/cloud-dev-config.yaml
@@ -9,6 +9,9 @@ ses:
   endpoint: email.us-east-1.amazonaws.com
   region: us-east-1
   from-address: noreply@sanctionco.com
+  success-html: success.html
+  verification-html: verification.html
+  verification-text: verification.txt
 
 # Approved Application Authentication Credentials
 approved-keys:

--- a/config/local-dev-config.yaml
+++ b/config/local-dev-config.yaml
@@ -9,6 +9,9 @@ ses:
   endpoint: http://localhost:9001
   region: us-east-1
   from-address: noreply@sanctionco.com
+  success-html: success.html
+  verification-html: verification.html
+  verification-text: verification.txt
 
 # Approved Application Authentication Credentials
 approved-keys:

--- a/config/prod-config.yaml
+++ b/config/prod-config.yaml
@@ -9,6 +9,9 @@ ses:
   endpoint: email.us-east-1.amazonaws.com
   region: us-east-1
   from-address: noreply@sanctionco.com
+  success-html: success.html
+  verification-html: verification.html
+  verification-text: verification.txt
 
 # Approved Application Authentication Credentials
 approved-keys:

--- a/config/test-config.yaml
+++ b/config/test-config.yaml
@@ -9,6 +9,9 @@ ses:
   endpoint: http://localhost:9001
   region: us-east-1
   from-address: noreply@sanctionco.com
+  success-html: success.html
+  verification-html: verification.html
+  verification-text: verification.txt
 
 # Approved Application Authentication Credentials
 approved-keys:


### PR DESCRIPTION
### This PR addresses:

<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists -->

This address issue #135. Users can specify an HTML file in the resources directory to be served to users when their email has been validated and when emailing users about email verification.

### I have verified that:

<!-- Ensure all of these boxes are checked -->
- [x] All related unit tests have been updated/created
- [  ] Integration tests are passing

### Additional Notes

<!-- Put any other additional notes here for reviewers -->


