### PR TITLE
User Property Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Thunder is used as part of the backend for [Pilot](https://github.com/RohanNagar
   ```json
   {
     "email" : {
-      "address": "sampleuser@sanctionco.com"
+      "address" : "sampleuser@sanctionco.com"
     },
     "password" : "12345",
-    "facebookAccessToken" : "facebookAccessToken",
-    "twitterAccessToken" : "twitterAccessToken",
-    "twitterAccessSecret" : "twitterAccessSecret"
+    "properties" : {
+      "myProperty" : 100
+    }
   }
   ```
   

--- a/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
@@ -42,13 +42,6 @@ class ThunderConfiguration extends Configuration {
     return approvedKeys;
   }
 
-  @JsonProperty("propertyValidation")
-  private final boolean propertyValidation = false;
-
-  boolean getPropertyValidation() {
-    return propertyValidation;
-  }
-
   @Valid
   @JsonProperty("properties")
   private final List<PropertyValidationRule> validationRules = null;

--- a/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
@@ -1,12 +1,12 @@
 package com.sanction.thunder;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.sanction.thunder.authentication.Key;
 
+import com.sanction.thunder.authentication.Key;
 import com.sanction.thunder.dynamodb.DynamoDbConfiguration;
 import com.sanction.thunder.email.EmailConfiguration;
-
 import com.sanction.thunder.validation.PropertyValidationRule;
+
 import io.dropwizard.Configuration;
 
 import java.util.List;

--- a/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderConfiguration.java
@@ -6,6 +6,7 @@ import com.sanction.thunder.authentication.Key;
 import com.sanction.thunder.dynamodb.DynamoDbConfiguration;
 import com.sanction.thunder.email.EmailConfiguration;
 
+import com.sanction.thunder.validation.PropertyValidationRule;
 import io.dropwizard.Configuration;
 
 import java.util.List;
@@ -39,5 +40,20 @@ class ThunderConfiguration extends Configuration {
 
   List<Key> getApprovedKeys() {
     return approvedKeys;
+  }
+
+  @JsonProperty("propertyValidation")
+  private final boolean propertyValidation = false;
+
+  boolean getPropertyValidation() {
+    return propertyValidation;
+  }
+
+  @Valid
+  @JsonProperty("properties")
+  private final List<PropertyValidationRule> validationRules = null;
+
+  List<PropertyValidationRule> getValidationRules() {
+    return validationRules;
   }
 }

--- a/application/src/main/java/com/sanction/thunder/ThunderModule.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderModule.java
@@ -3,8 +3,8 @@ package com.sanction.thunder;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sanction.thunder.authentication.Key;
-
 import com.sanction.thunder.validation.PropertyValidator;
+
 import dagger.Module;
 import dagger.Provides;
 

--- a/application/src/main/java/com/sanction/thunder/ThunderModule.java
+++ b/application/src/main/java/com/sanction/thunder/ThunderModule.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sanction.thunder.authentication.Key;
 
+import com.sanction.thunder.validation.PropertyValidator;
 import dagger.Module;
 import dagger.Provides;
 
@@ -38,5 +39,11 @@ public class ThunderModule {
   @Provides
   List<Key> provideApprovedKeys() {
     return config.getApprovedKeys();
+  }
+
+  @Singleton
+  @Provides
+  PropertyValidator providePropertyValidator() {
+    return new PropertyValidator(config.getValidationRules());
   }
 }

--- a/application/src/main/java/com/sanction/thunder/resources/UserResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/UserResource.java
@@ -95,6 +95,12 @@ public class UserResource {
           .entity("Cannot post a user without an email address.").build();
     }
 
+    if (!isValidEmail(user.getEmail().getAddress())) {
+      LOG.error("The new user has an invalid email address: {}", user.getEmail());
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity("Invalid email address format. Please try again.").build();
+    }
+
     if (!propertyValidator.isValidPropertiesMap(user.getProperties())) {
       LOG.warn("Attempted to post a user with invalid properties.");
       return Response.status(Response.Status.BAD_REQUEST)
@@ -102,12 +108,6 @@ public class UserResource {
     }
 
     LOG.info("Attempting to create new user {}.", user.getEmail().getAddress());
-
-    if (!isValidEmail(user.getEmail().getAddress())) {
-      LOG.error("The new user has an invalid email address: {}", user.getEmail());
-      return Response.status(Response.Status.BAD_REQUEST)
-          .entity("Invalid email address format. Please try again.").build();
-    }
 
     // Update the user to non-verified status
     User updatedUser = new User(
@@ -173,6 +173,12 @@ public class UserResource {
       LOG.warn("Attempted to update user {} without a password.", email);
       return Response.status(Response.Status.BAD_REQUEST)
           .entity("Incorrect or missing header credentials.").build();
+    }
+
+    if (!propertyValidator.isValidPropertiesMap(user.getProperties())) {
+      LOG.warn("Attempted to update a user with new invalid properties.");
+      return Response.status(Response.Status.BAD_REQUEST)
+          .entity("Cannot post a user with invalid properties").build();
     }
 
     User foundUser;

--- a/application/src/main/java/com/sanction/thunder/resources/UserResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/UserResource.java
@@ -7,8 +7,8 @@ import com.sanction.thunder.dao.DatabaseException;
 import com.sanction.thunder.dao.UsersDao;
 import com.sanction.thunder.models.Email;
 import com.sanction.thunder.models.User;
-
 import com.sanction.thunder.validation.PropertyValidator;
+
 import io.dropwizard.auth.Auth;
 
 import javax.inject.Inject;
@@ -34,8 +34,8 @@ import org.slf4j.LoggerFactory;
 public class UserResource {
   private static final Logger LOG = LoggerFactory.getLogger(UserResource.class);
 
-  private final UsersDao usersDao;
   private final PropertyValidator propertyValidator;
+  private final UsersDao usersDao;
 
   // Counts number of requests
   private final Meter postRequests;

--- a/application/src/main/java/com/sanction/thunder/validation/PropertyValidationRule.java
+++ b/application/src/main/java/com/sanction/thunder/validation/PropertyValidationRule.java
@@ -1,0 +1,53 @@
+package com.sanction.thunder.validation;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+public class PropertyValidationRule {
+  private final String name;
+  private final Class type;
+
+  public PropertyValidationRule(@JsonProperty("name") String name,
+                                @JsonProperty("type") String type) {
+    this.name = name;
+    this.type = type.equalsIgnoreCase("string") ? String.class : Object.class;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Class getType() {
+    return type;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof PropertyValidationRule)) {
+      return false;
+    }
+
+    PropertyValidationRule other = (PropertyValidationRule) obj;
+    return Objects.equals(this.name, other.name)
+        && Objects.equals(this.type, other.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.name, this.type);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", "PropertyValidationRule [", "]")
+        .add(String.format("name=%s", name))
+        .add(String.format("type=%s", type))
+        .toString();
+  }
+}

--- a/application/src/main/java/com/sanction/thunder/validation/PropertyValidationRule.java
+++ b/application/src/main/java/com/sanction/thunder/validation/PropertyValidationRule.java
@@ -12,7 +12,7 @@ public class PropertyValidationRule {
   public PropertyValidationRule(@JsonProperty("name") String name,
                                 @JsonProperty("type") String type) {
     this.name = name;
-    this.type = type.equalsIgnoreCase("string") ? String.class : Object.class;
+    this.type = PropertyValidator.getType(type);
   }
 
   public String getName() {

--- a/application/src/main/java/com/sanction/thunder/validation/PropertyValidator.java
+++ b/application/src/main/java/com/sanction/thunder/validation/PropertyValidator.java
@@ -1,0 +1,23 @@
+package com.sanction.thunder.validation;
+
+import java.util.List;
+import java.util.Map;
+
+public class PropertyValidator {
+  private final List<PropertyValidationRule> validationRules;
+
+  public PropertyValidator(List<PropertyValidationRule> validationRules) {
+    this.validationRules = validationRules;
+  }
+
+  /**
+   * Determines if a given property map is valid.
+   * @param properties The property map to test for validity.
+   * @return True if the property map is valid, false otherwise.
+   */
+  public boolean isValidPropertiesMap(Map<String, Object> properties) {
+    return validationRules.stream()
+        .allMatch(rule -> properties.containsKey(rule.getName())
+            && rule.getType().isInstance(properties.get(rule.getName())));
+  }
+}

--- a/application/src/main/java/com/sanction/thunder/validation/PropertyValidator.java
+++ b/application/src/main/java/com/sanction/thunder/validation/PropertyValidator.java
@@ -3,11 +3,18 @@ package com.sanction.thunder.validation;
 import java.util.List;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class PropertyValidator {
+  private static final Logger LOG = LoggerFactory.getLogger(PropertyValidator.class);
+
   private final List<PropertyValidationRule> validationRules;
+  private final boolean shouldValidateProperties;
 
   public PropertyValidator(List<PropertyValidationRule> validationRules) {
     this.validationRules = validationRules;
+    this.shouldValidateProperties = validationRules != null;
   }
 
   /**
@@ -16,8 +23,50 @@ public class PropertyValidator {
    * @return True if the property map is valid, false otherwise.
    */
   public boolean isValidPropertiesMap(Map<String, Object> properties) {
+    if (!shouldValidateProperties) {
+      LOG.info("Skipping property validation because none was specified.");
+      return true;
+    }
+
+    // Check for size
+    if (properties.size() != validationRules.size()) {
+      LOG.info("Properties size does not match the number of validation rules.");
+      return false;
+    }
+
+    // Match name and type
     return validationRules.stream()
         .allMatch(rule -> properties.containsKey(rule.getName())
             && rule.getType().isInstance(properties.get(rule.getName())));
+  }
+
+  /**
+   * Determines the Class object for a given string.
+   * @param typename The string to parse the class object for.
+   * @return The type that is represented by the string.
+   */
+  public static Class getType(String typename) {
+    switch (typename) {
+      case "string":
+        return String.class;
+
+      case "integer":
+        return Integer.class;
+
+      case "boolean":
+        return Boolean.class;
+
+      case "double":
+        return Double.class;
+
+      case "list":
+        return List.class;
+
+      case "map":
+        return Map.class;
+
+      default:
+        return Object.class;
+    }
   }
 }

--- a/application/src/main/java/com/sanction/thunder/validation/PropertyValidator.java
+++ b/application/src/main/java/com/sanction/thunder/validation/PropertyValidator.java
@@ -18,13 +18,13 @@ public class PropertyValidator {
   }
 
   /**
-   * Determines if a given property map is valid.
+   * Determines if a given User property map is valid, based on the validation rules.
    * @param properties The property map to test for validity.
    * @return True if the property map is valid, false otherwise.
    */
   public boolean isValidPropertiesMap(Map<String, Object> properties) {
     if (!shouldValidateProperties) {
-      LOG.info("Skipping property validation because none was specified.");
+      LOG.info("Skipping property validation because no properties were specified.");
       return true;
     }
 
@@ -41,8 +41,8 @@ public class PropertyValidator {
   }
 
   /**
-   * Determines the Class object for a given string.
-   * @param typename The string to parse the class object for.
+   * Determines the Class represented by a given string.
+   * @param typename The string to parse.
    * @return The type that is represented by the string.
    */
   public static Class getType(String typename) {

--- a/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import com.sanction.thunder.authentication.Key;
 
+import com.sanction.thunder.validation.PropertyValidationRule;
 import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
@@ -38,5 +39,10 @@ public class ThunderConfigurationTest {
     assertEquals(
         Collections.singletonList(new Key("test-app", "test-secret")),
         configuration.getApprovedKeys());
+
+    assertEquals(1, configuration.getValidationRules().size());
+    assertEquals(
+        new PropertyValidationRule("testProperty", "list"),
+        configuration.getValidationRules().get(0));
   }
 }

--- a/application/src/test/java/com/sanction/thunder/resources/UserResourceTest.java
+++ b/application/src/test/java/com/sanction/thunder/resources/UserResourceTest.java
@@ -29,7 +29,7 @@ public class UserResourceTest {
   private final MetricRegistry metrics = new MetricRegistry();
   private final Key key = mock(Key.class);
 
-  private final UserResource resource = new UserResource(usersDao, metrics);
+  private final UserResource resource = new UserResource(usersDao, null, metrics);
 
   @Test
   public void testPostNullUser() {
@@ -46,54 +46,54 @@ public class UserResourceTest {
     assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
   }
 
-  @Test
-  public void testPostUserInvalidEmail() {
-    User user = new User(badEmail, "password", Collections.emptyMap());
-    Response response = resource.postUser(key, user);
+  //@Test
+  //public void testPostUserInvalidEmail() {
+  //  User user = new User(badEmail, "password", Collections.emptyMap());
+  //  Response response = resource.postUser(key, user);
 
-    assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
-  }
+  //  assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
+  //}
 
-  @Test
-  public void testPostUserDatabaseDown() {
-    when(usersDao.insert(any(User.class)))
-        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
+  //@Test
+  //public void testPostUserDatabaseDown() {
+  //  when(usersDao.insert(any(User.class)))
+  //      .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
 
-    Response response = resource.postUser(key, user);
+  //  Response response = resource.postUser(key, user);
 
-    assertEquals(Response.Status.SERVICE_UNAVAILABLE, response.getStatusInfo());
-  }
+  //  assertEquals(Response.Status.SERVICE_UNAVAILABLE, response.getStatusInfo());
+  //}
 
-  @Test
-  public void testPostUserUnsupportedData() {
-    when(usersDao.insert(any(User.class))).thenThrow(
-        new DatabaseException(DatabaseError.REQUEST_REJECTED));
+  //@Test
+  //public void testPostUserUnsupportedData() {
+  //  when(usersDao.insert(any(User.class))).thenThrow(
+  //      new DatabaseException(DatabaseError.REQUEST_REJECTED));
 
-    Response response = resource.postUser(key, user);
+  //  Response response = resource.postUser(key, user);
 
-    assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
-  }
+  //  assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
+  //}
 
-  @Test
-  public void testPostUserConflict() {
-    when(usersDao.insert(any(User.class)))
-        .thenThrow(new DatabaseException(DatabaseError.CONFLICT));
+  //@Test
+  //public void testPostUserConflict() {
+  //  when(usersDao.insert(any(User.class)))
+  //      .thenThrow(new DatabaseException(DatabaseError.CONFLICT));
 
-    Response response = resource.postUser(key, user);
+  //  Response response = resource.postUser(key, user);
 
-    assertEquals(Response.Status.CONFLICT, response.getStatusInfo());
-  }
+  //  assertEquals(Response.Status.CONFLICT, response.getStatusInfo());
+  //}
 
-  @Test
-  public void testPostUser() {
-    when(usersDao.insert(any(User.class))).thenReturn(updatedUser);
+  //@Test
+  //public void testPostUser() {
+  //  when(usersDao.insert(any(User.class))).thenReturn(updatedUser);
 
-    Response response = resource.postUser(key, user);
-    User result = (User) response.getEntity();
+  //  Response response = resource.postUser(key, user);
+  //  User result = (User) response.getEntity();
 
-    assertEquals(Response.Status.CREATED, response.getStatusInfo());
-    assertEquals(updatedUser, result);
-  }
+  //  assertEquals(Response.Status.CREATED, response.getStatusInfo());
+  //  assertEquals(updatedUser, result);
+  //}
 
   @Test
   public void testUpdateNullUser() {

--- a/application/src/test/java/com/sanction/thunder/resources/UserResourceTest.java
+++ b/application/src/test/java/com/sanction/thunder/resources/UserResourceTest.java
@@ -8,14 +8,17 @@ import com.sanction.thunder.dao.DatabaseException;
 import com.sanction.thunder.dao.UsersDao;
 import com.sanction.thunder.models.Email;
 import com.sanction.thunder.models.User;
+import com.sanction.thunder.validation.PropertyValidator;
 
 import java.util.Collections;
 import javax.ws.rs.core.Response;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,10 +29,16 @@ public class UserResourceTest {
   private final User updatedUser = new User(email, "newPassword", Collections.emptyMap());
 
   private final UsersDao usersDao = mock(UsersDao.class);
+  private final PropertyValidator validator = mock(PropertyValidator.class);
   private final MetricRegistry metrics = new MetricRegistry();
   private final Key key = mock(Key.class);
 
-  private final UserResource resource = new UserResource(usersDao, null, metrics);
+  private final UserResource resource = new UserResource(usersDao, validator, metrics);
+
+  @Before
+  public void setup() {
+    when(validator.isValidPropertiesMap(anyMap())).thenReturn(true);
+  }
 
   @Test
   public void testPostNullUser() {
@@ -46,54 +55,63 @@ public class UserResourceTest {
     assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
   }
 
-  //@Test
-  //public void testPostUserInvalidEmail() {
-  //  User user = new User(badEmail, "password", Collections.emptyMap());
-  //  Response response = resource.postUser(key, user);
+  @Test
+  public void testPostUserInvalidEmail() {
+    User user = new User(badEmail, "password", Collections.emptyMap());
+    Response response = resource.postUser(key, user);
 
-  //  assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
-  //}
+    assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
+  }
 
-  //@Test
-  //public void testPostUserDatabaseDown() {
-  //  when(usersDao.insert(any(User.class)))
-  //      .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
+  @Test
+  public void testPostUserInvalidProperties() {
+    when(validator.isValidPropertiesMap(anyMap())).thenReturn(false);
 
-  //  Response response = resource.postUser(key, user);
+    Response response = resource.postUser(key, user);
 
-  //  assertEquals(Response.Status.SERVICE_UNAVAILABLE, response.getStatusInfo());
-  //}
+    assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
+  }
 
-  //@Test
-  //public void testPostUserUnsupportedData() {
-  //  when(usersDao.insert(any(User.class))).thenThrow(
-  //      new DatabaseException(DatabaseError.REQUEST_REJECTED));
+  @Test
+  public void testPostUserDatabaseDown() {
+    when(usersDao.insert(any(User.class)))
+        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
 
-  //  Response response = resource.postUser(key, user);
+    Response response = resource.postUser(key, user);
 
-  //  assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
-  //}
+    assertEquals(Response.Status.SERVICE_UNAVAILABLE, response.getStatusInfo());
+  }
 
-  //@Test
-  //public void testPostUserConflict() {
-  //  when(usersDao.insert(any(User.class)))
-  //      .thenThrow(new DatabaseException(DatabaseError.CONFLICT));
+  @Test
+  public void testPostUserUnsupportedData() {
+    when(usersDao.insert(any(User.class))).thenThrow(
+        new DatabaseException(DatabaseError.REQUEST_REJECTED));
 
-  //  Response response = resource.postUser(key, user);
+    Response response = resource.postUser(key, user);
 
-  //  assertEquals(Response.Status.CONFLICT, response.getStatusInfo());
-  //}
+    assertEquals(Response.Status.INTERNAL_SERVER_ERROR, response.getStatusInfo());
+  }
 
-  //@Test
-  //public void testPostUser() {
-  //  when(usersDao.insert(any(User.class))).thenReturn(updatedUser);
+  @Test
+  public void testPostUserConflict() {
+    when(usersDao.insert(any(User.class)))
+        .thenThrow(new DatabaseException(DatabaseError.CONFLICT));
 
-  //  Response response = resource.postUser(key, user);
-  //  User result = (User) response.getEntity();
+    Response response = resource.postUser(key, user);
 
-  //  assertEquals(Response.Status.CREATED, response.getStatusInfo());
-  //  assertEquals(updatedUser, result);
-  //}
+    assertEquals(Response.Status.CONFLICT, response.getStatusInfo());
+  }
+
+  @Test
+  public void testPostUser() {
+    when(usersDao.insert(any(User.class))).thenReturn(updatedUser);
+
+    Response response = resource.postUser(key, user);
+    User result = (User) response.getEntity();
+
+    assertEquals(Response.Status.CREATED, response.getStatusInfo());
+    assertEquals(updatedUser, result);
+  }
 
   @Test
   public void testUpdateNullUser() {
@@ -121,6 +139,15 @@ public class UserResourceTest {
   @Test
   public void testUpdateUserWithNullPassword() {
     Response response = resource.updateUser(key, null, null, user);
+
+    assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
+  }
+
+  @Test
+  public void testUpdateUserInvalidProperties() {
+    when(validator.isValidPropertiesMap(anyMap())).thenReturn(false);
+
+    Response response = resource.updateUser(key, "password", null, user);
 
     assertEquals(Response.Status.BAD_REQUEST, response.getStatusInfo());
   }

--- a/application/src/test/java/com/sanction/thunder/validation/PropertyValidationRuleTest.java
+++ b/application/src/test/java/com/sanction/thunder/validation/PropertyValidationRuleTest.java
@@ -1,0 +1,54 @@
+package com.sanction.thunder.validation;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PropertyValidationRuleTest {
+
+  @Test
+  public void testHashCodeSame() {
+    PropertyValidationRule keyOne = new PropertyValidationRule("name", "string");
+    PropertyValidationRule keyTwo = new PropertyValidationRule("name", "string");
+
+    assertEquals(keyOne.hashCode(), keyTwo.hashCode());
+    assertEquals(keyOne.getName(), keyTwo.getName());
+    assertEquals(keyOne.getType(), keyTwo.getType());
+  }
+
+  @Test
+  public void testHashCodeDifferent() {
+    PropertyValidationRule keyOne = new PropertyValidationRule("name", "string");
+    PropertyValidationRule keyTwo = new PropertyValidationRule("differentName", "integer");
+
+    assertNotEquals(keyOne.hashCode(), keyTwo.hashCode());
+    assertNotEquals(keyOne.getName(), keyTwo.getName());
+    assertNotEquals(keyOne.getType(), keyTwo.getType());
+  }
+
+  @Test
+  public void testEqualsSameObject() {
+    PropertyValidationRule keyOne = new PropertyValidationRule("name", "list");
+
+    assertTrue(keyOne.equals(keyOne));
+  }
+
+  @Test
+  public void testEqualsDifferentObject() {
+    PropertyValidationRule keyOne = new PropertyValidationRule("name", "map");
+    Object objectTwo = new Object();
+
+    assertFalse(keyOne.equals(objectTwo));
+  }
+
+  @Test
+  public void testToString() {
+    PropertyValidationRule key = new PropertyValidationRule("testName", "string");
+    String expected = "PropertyValidationRule [name=testName, type=class java.lang.String]";
+
+    assertEquals(expected, key.toString());
+  }
+}

--- a/application/src/test/java/com/sanction/thunder/validation/PropertyValidationRuleTest.java
+++ b/application/src/test/java/com/sanction/thunder/validation/PropertyValidationRuleTest.java
@@ -11,44 +11,44 @@ public class PropertyValidationRuleTest {
 
   @Test
   public void testHashCodeSame() {
-    PropertyValidationRule keyOne = new PropertyValidationRule("name", "string");
-    PropertyValidationRule keyTwo = new PropertyValidationRule("name", "string");
+    PropertyValidationRule ruleOne = new PropertyValidationRule("name", "string");
+    PropertyValidationRule ruleTwo = new PropertyValidationRule("name", "string");
 
-    assertEquals(keyOne.hashCode(), keyTwo.hashCode());
-    assertEquals(keyOne.getName(), keyTwo.getName());
-    assertEquals(keyOne.getType(), keyTwo.getType());
+    assertEquals(ruleOne.hashCode(), ruleTwo.hashCode());
+    assertEquals(ruleOne.getName(), ruleTwo.getName());
+    assertEquals(ruleOne.getType(), ruleTwo.getType());
   }
 
   @Test
   public void testHashCodeDifferent() {
-    PropertyValidationRule keyOne = new PropertyValidationRule("name", "string");
-    PropertyValidationRule keyTwo = new PropertyValidationRule("differentName", "integer");
+    PropertyValidationRule ruleOne = new PropertyValidationRule("name", "string");
+    PropertyValidationRule ruleTwo = new PropertyValidationRule("differentName", "integer");
 
-    assertNotEquals(keyOne.hashCode(), keyTwo.hashCode());
-    assertNotEquals(keyOne.getName(), keyTwo.getName());
-    assertNotEquals(keyOne.getType(), keyTwo.getType());
+    assertNotEquals(ruleOne.hashCode(), ruleTwo.hashCode());
+    assertNotEquals(ruleOne.getName(), ruleTwo.getName());
+    assertNotEquals(ruleOne.getType(), ruleTwo.getType());
   }
 
   @Test
   public void testEqualsSameObject() {
-    PropertyValidationRule keyOne = new PropertyValidationRule("name", "list");
+    PropertyValidationRule ruleOne = new PropertyValidationRule("name", "list");
 
-    assertTrue(keyOne.equals(keyOne));
+    assertTrue(ruleOne.equals(ruleOne));
   }
 
   @Test
   public void testEqualsDifferentObject() {
-    PropertyValidationRule keyOne = new PropertyValidationRule("name", "map");
+    PropertyValidationRule ruleOne = new PropertyValidationRule("name", "map");
     Object objectTwo = new Object();
 
-    assertFalse(keyOne.equals(objectTwo));
+    assertFalse(ruleOne.equals(objectTwo));
   }
 
   @Test
   public void testToString() {
-    PropertyValidationRule key = new PropertyValidationRule("testName", "string");
+    PropertyValidationRule rule = new PropertyValidationRule("testName", "string");
     String expected = "PropertyValidationRule [name=testName, type=class java.lang.String]";
 
-    assertEquals(expected, key.toString());
+    assertEquals(expected, rule.toString());
   }
 }

--- a/application/src/test/java/com/sanction/thunder/validation/PropertyValidatorTest.java
+++ b/application/src/test/java/com/sanction/thunder/validation/PropertyValidatorTest.java
@@ -1,5 +1,7 @@
 package com.sanction.thunder.validation;
 
+import com.google.common.collect.ImmutableMap;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -21,6 +23,7 @@ public class PropertyValidatorTest {
   @Test
   public void testSkipValidation() {
     PropertyValidator validator = new PropertyValidator(null);
+    Map<String, Object> properties = Collections.emptyMap();
 
     assertTrue(validator.isValidPropertiesMap(properties));
   }
@@ -28,6 +31,7 @@ public class PropertyValidatorTest {
   @Test
   public void testInvalidSize() {
     PropertyValidator validator = new PropertyValidator(validationRules);
+    Map<String, Object> properties = Collections.emptyMap();
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -35,7 +39,7 @@ public class PropertyValidatorTest {
   @Test
   public void testMismatchName() {
     PropertyValidator validator = new PropertyValidator(validationRules);
-    properties.put("myProperty", "value");
+    Map<String, Object> properties = Collections.singletonMap("myProperty", "value");
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -44,9 +48,7 @@ public class PropertyValidatorTest {
   @Test
   public void testMismatchTypeString() {
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.clear();
-    properties.put("firstProperty", 1);
+    Map<String, Object> properties = Collections.singletonMap("firstProperty", 1);
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -54,8 +56,7 @@ public class PropertyValidatorTest {
   @Test
   public void testSuccessfulStringValidation() {
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.put("firstProperty", "value");
+    Map<String, Object> properties = Collections.singletonMap("firstProperty", "value");
 
     assertTrue(validator.isValidPropertiesMap(properties));
   }
@@ -68,8 +69,9 @@ public class PropertyValidatorTest {
         new PropertyValidationRule("secondProperty", "integer"));
 
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.put("secondProperty", "1");
+    Map<String, Object> properties = ImmutableMap.of(
+        "firstProperty", "value",
+        "secondProperty", "1");
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -77,8 +79,9 @@ public class PropertyValidatorTest {
   @Test
   public void testSuccessfulIntegerValidation() {
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.put("secondProperty", 1);
+    Map<String, Object> properties = ImmutableMap.of(
+        "firstProperty", "value",
+        "secondProperty", 1);
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -92,8 +95,10 @@ public class PropertyValidatorTest {
         new PropertyValidationRule("thirdProperty", "boolean"));
 
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.put("thirdProperty", "false");
+    Map<String, Object> properties = ImmutableMap.of(
+        "firstProperty", "value",
+        "secondProperty", 1,
+        "thirdProperty", "false");
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -101,8 +106,10 @@ public class PropertyValidatorTest {
   @Test
   public void testSuccessfulBooleanValidation() {
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.put("thirdProperty", false);
+    Map<String, Object> properties = ImmutableMap.of(
+        "firstProperty", "value",
+        "secondProperty", 1,
+        "thirdProperty", false);
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -117,8 +124,11 @@ public class PropertyValidatorTest {
         new PropertyValidationRule("fourthProperty", "double"));
 
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.put("fourthProperty", 1);
+    Map<String, Object> properties = ImmutableMap.of(
+        "firstProperty", "value",
+        "secondProperty", 1,
+        "thirdProperty", false,
+        "fourthProperty", 1);
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -126,8 +136,11 @@ public class PropertyValidatorTest {
   @Test
   public void testSuccessfulDoubleValidation() {
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.put("fourthProperty", 1.0);
+    Map<String, Object> properties = ImmutableMap.of(
+        "firstProperty", "value",
+        "secondProperty", 1,
+        "thirdProperty", false,
+        "fourthProperty", 1.0);
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -143,8 +156,12 @@ public class PropertyValidatorTest {
         new PropertyValidationRule("fifthProperty", "list"));
 
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.put("fifthProperty", Collections.emptyMap());
+    Map<String, Object> properties = ImmutableMap.of(
+        "firstProperty", "value",
+        "secondProperty", 1,
+        "thirdProperty", false,
+        "fourthProperty", 1.0,
+        "fifthProperty", Collections.emptyMap());
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -152,8 +169,12 @@ public class PropertyValidatorTest {
   @Test
   public void testSuccessfulListValidation() {
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.put("fifthProperty", Collections.emptyList());
+    Map<String, Object> properties = ImmutableMap.of(
+        "firstProperty", "value",
+        "secondProperty", 1,
+        "thirdProperty", false,
+        "fourthProperty", 1.0,
+        "fifthProperty", Collections.emptyList());
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -170,8 +191,12 @@ public class PropertyValidatorTest {
         new PropertyValidationRule("sixthProperty", "map"));
 
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.put("sixthProperty", Collections.emptyList());
+    Map<String, Object> properties = ImmutableMap.of(
+        "firstProperty", "value",
+        "secondProperty", 1,
+        "thirdProperty", false,
+        "fourthProperty", 1.0,
+        "fifthProperty", Collections.emptyList());
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }
@@ -179,8 +204,12 @@ public class PropertyValidatorTest {
   @Test
   public void testSuccessfulMapValidation() {
     PropertyValidator validator = new PropertyValidator(validationRules);
-
-    properties.put("sixthProperty", Collections.emptyMap());
+    Map<String, Object> properties = ImmutableMap.of(
+        "firstProperty", "value",
+        "secondProperty", 1,
+        "thirdProperty", false,
+        "fourthProperty", 1.0,
+        "fifthProperty", Collections.emptyMap());
 
     assertFalse(validator.isValidPropertiesMap(properties));
   }

--- a/application/src/test/java/com/sanction/thunder/validation/PropertyValidatorTest.java
+++ b/application/src/test/java/com/sanction/thunder/validation/PropertyValidatorTest.java
@@ -1,0 +1,198 @@
+package com.sanction.thunder.validation;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PropertyValidatorTest {
+  private final Map<String, Object> properties = new HashMap<>();
+  private List<PropertyValidationRule> validationRules
+      = Collections.singletonList(
+          new PropertyValidationRule("firstProperty", "string"));
+
+  @Test
+  public void testSkipValidation() {
+    PropertyValidator validator = new PropertyValidator(null);
+
+    assertTrue(validator.isValidPropertiesMap(properties));
+  }
+
+  @Test
+  public void testInvalidSize() {
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  @Test
+  public void testMismatchName() {
+    PropertyValidator validator = new PropertyValidator(validationRules);
+    properties.put("myProperty", "value");
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  /* String type */
+  @Test
+  public void testMismatchTypeString() {
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.clear();
+    properties.put("firstProperty", 1);
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  @Test
+  public void testSuccessfulStringValidation() {
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.put("firstProperty", "value");
+
+    assertTrue(validator.isValidPropertiesMap(properties));
+  }
+
+  /* Integer type */
+  @Test
+  public void testMismatchTypeInteger() {
+    validationRules = Arrays.asList(
+        new PropertyValidationRule("firstProperty", "string"),
+        new PropertyValidationRule("secondProperty", "integer"));
+
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.put("secondProperty", "1");
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  @Test
+  public void testSuccessfulIntegerValidation() {
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.put("secondProperty", 1);
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  /* Boolean type */
+  @Test
+  public void testMismatchTypeBoolean() {
+    validationRules = Arrays.asList(
+        new PropertyValidationRule("firstProperty", "string"),
+        new PropertyValidationRule("secondProperty", "integer"),
+        new PropertyValidationRule("thirdProperty", "boolean"));
+
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.put("thirdProperty", "false");
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  @Test
+  public void testSuccessfulBooleanValidation() {
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.put("thirdProperty", false);
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  /* Boolean type */
+  @Test
+  public void testMismatchTypeDouble() {
+    validationRules = Arrays.asList(
+        new PropertyValidationRule("firstProperty", "string"),
+        new PropertyValidationRule("secondProperty", "integer"),
+        new PropertyValidationRule("thirdProperty", "boolean"),
+        new PropertyValidationRule("fourthProperty", "double"));
+
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.put("fourthProperty", 1);
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  @Test
+  public void testSuccessfulDoubleValidation() {
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.put("fourthProperty", 1.0);
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  /* List type */
+  @Test
+  public void testMismatchTypeList() {
+    validationRules = Arrays.asList(
+        new PropertyValidationRule("firstProperty", "string"),
+        new PropertyValidationRule("secondProperty", "integer"),
+        new PropertyValidationRule("thirdProperty", "boolean"),
+        new PropertyValidationRule("fourthProperty", "double"),
+        new PropertyValidationRule("fifthProperty", "list"));
+
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.put("fifthProperty", Collections.emptyMap());
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  @Test
+  public void testSuccessfulListValidation() {
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.put("fifthProperty", Collections.emptyList());
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  /* Map type */
+  @Test
+  public void testMismatchTypeMap() {
+    validationRules = Arrays.asList(
+        new PropertyValidationRule("firstProperty", "string"),
+        new PropertyValidationRule("secondProperty", "integer"),
+        new PropertyValidationRule("thirdProperty", "boolean"),
+        new PropertyValidationRule("fourthProperty", "double"),
+        new PropertyValidationRule("fifthProperty", "list"),
+        new PropertyValidationRule("sixthProperty", "map"));
+
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.put("sixthProperty", Collections.emptyList());
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  @Test
+  public void testSuccessfulMapValidation() {
+    PropertyValidator validator = new PropertyValidator(validationRules);
+
+    properties.put("sixthProperty", Collections.emptyMap());
+
+    assertFalse(validator.isValidPropertiesMap(properties));
+  }
+
+  @Test
+  public void testGetType() {
+    assertEquals(String.class, PropertyValidator.getType("string"));
+    assertEquals(Integer.class, PropertyValidator.getType("integer"));
+    assertEquals(Boolean.class, PropertyValidator.getType("boolean"));
+    assertEquals(Double.class, PropertyValidator.getType("double"));
+    assertEquals(List.class, PropertyValidator.getType("list"));
+    assertEquals(Map.class, PropertyValidator.getType("map"));
+    assertEquals(Object.class, PropertyValidator.getType("unknown"));
+  }
+}

--- a/application/src/test/resources/fixtures/config.yaml
+++ b/application/src/test/resources/fixtures/config.yaml
@@ -11,3 +11,7 @@ ses:
 approvedKeys:
   - application: test-app
     secret: test-secret
+
+properties:
+  - name: testProperty
+    type: list

--- a/config/property-validation-config.yaml
+++ b/config/property-validation-config.yaml
@@ -30,15 +30,3 @@ server:
   adminConnectors:
     - type: http
       port: 8081
-  requestLog:
-    appenders:
-      - type: file
-        currentLogFilename: ./log/thunder-requests.log
-        archivedLogFilenamePattern: ./log/thunder-requests-%d.log
-
-logging:
-  level: INFO
-  appenders:
-    - type: file
-      currentLogFilename: ./log/thunder.log
-      archivedLogFilenamePattern: ./log/thunder-%d.log

--- a/config/test-config.yaml
+++ b/config/test-config.yaml
@@ -15,6 +15,14 @@ approvedKeys:
   - application: application
     secret: secret
 
+properties:
+  - name: property1
+    type: string
+  - name: intproperty
+    type: integer
+  - name: mylist
+    type: list
+
 # Server configuration
 server:
   applicationConnectors:

--- a/scripts/.eslintrc.yml
+++ b/scripts/.eslintrc.yml
@@ -30,4 +30,3 @@ rules:
     - error
     - requireReturn: false
       requireReturnType: false
-

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,4 +51,3 @@ $ node src/run-thunder-command.js
 Use this script to run an individual Thunder command such as `GET` or `DELETE`.
 More information can be found in the
 [wiki](https://github.com/RohanNagar/thunder/wiki/Running-Node.js-Scripts#single-operations).
-

--- a/scripts/aws/dynamo-table.yaml
+++ b/scripts/aws/dynamo-table.yaml
@@ -19,4 +19,3 @@ Resources:
         WriteCapacityUnits: "5"
       TableName:
         Ref: TableName
-

--- a/scripts/kubernetes/thunder-config.yaml
+++ b/scripts/kubernetes/thunder-config.yaml
@@ -25,4 +25,3 @@ data:
       adminConnectors:
         - type: http
           port: 8081
-

--- a/scripts/kubernetes/thunder-deployment.yaml
+++ b/scripts/kubernetes/thunder-deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: thunder
-          image: rohannagar/thunder:test
+          image: rohannagar/thunder:edge
           imagePullPolicy: Always
           env:
             - name: AWS_ACCESS_KEY_ID
@@ -52,4 +52,3 @@ spec:
       targetPort: 8080
   selector:
     app: thunder
-

--- a/scripts/resources/user_details.json
+++ b/scripts/resources/user_details.json
@@ -4,6 +4,8 @@
   },
   "password" : "5f4dcc3b5aa765d61d8327deb882cf99",
   "properties" : {
-    "facebookAccessToken" : "fbToken"
+    "property1" : "test",
+    "intproperty" : 1,
+    "mylist": ["woah"]
   }
 }

--- a/scripts/resources/user_details.json
+++ b/scripts/resources/user_details.json
@@ -1,11 +1,10 @@
 {
-  "email" : {
+  "email": {
     "address": "success@simulator.amazonses.com"
   },
-  "password" : "5f4dcc3b5aa765d61d8327deb882cf99",
-  "properties" : {
-    "property1" : "test",
-    "intproperty" : 1,
-    "mylist": ["woah"]
+  "password": "5f4dcc3b5aa765d61d8327deb882cf99",
+  "properties": {
+    "uniqueID": "ABC123",
+    "attributes": ["hello", "world"]
   }
 }

--- a/scripts/src/aws-client.js
+++ b/scripts/src/aws-client.js
@@ -33,4 +33,3 @@ function createDynamoTable(tableName, callback) {
 module.exports = {
   createDynamoTable
 };
-

--- a/scripts/src/run-thunder-command.js
+++ b/scripts/src/run-thunder-command.js
@@ -150,4 +150,3 @@ switch (args.command) {
 
     break;
 }
-

--- a/scripts/src/test-runner.js
+++ b/scripts/src/test-runner.js
@@ -142,7 +142,7 @@ function verify(data, callback) {
 }
 
 /**
- * Updates the `facebookAccessToken` field in the Thunder user.
+ * Updates the `uniqueID` field in the Thunder user.
  *
  * @param {object} data - The user data to perform an update on.
  * @param {function} callback - The function to call on completion.
@@ -151,7 +151,7 @@ function verify(data, callback) {
 function updateField(data, callback) {
   console.log('Attempting to update the user\'s Facebook access token...');
 
-  data.properties.facebookAccessToken = Date.now();
+  data.properties.uniqueID = Date.now().toString();
   return thunder.updateUser(null, data.password, data, (err, result) => {
     handleResponse(err, result, 'UPDATE', callback);
   });

--- a/scripts/src/test-runner.js
+++ b/scripts/src/test-runner.js
@@ -253,4 +253,3 @@ async.waterfall(testPipeline, (err, result) => {
     process.exit();
   }
 });
-

--- a/scripts/tools/bootstrap.sh
+++ b/scripts/tools/bootstrap.sh
@@ -260,4 +260,3 @@ echo "Everything is done. Current package versions:"
 check_java_version
 check_maven_version
 check_node_version
-

--- a/scripts/tools/integration-tests.sh
+++ b/scripts/tools/integration-tests.sh
@@ -41,4 +41,3 @@ else
     echo "There are integration test failures."
     exit 1
 fi
-

--- a/scripts/tools/run-local-dependencies.js
+++ b/scripts/tools/run-local-dependencies.js
@@ -39,4 +39,3 @@ process.on('exit', () => {
 
 // -- Ready to go --
 console.log('All dependencies ready! Kill this process to shut them all down.');
-


### PR DESCRIPTION
### This PR addresses:

<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists -->
Addresses most of #143.

- User properties are validated on `POST` and `PUT`! 🎉
- Property validation is optional. Turn it on by specifying the `properties` section in the `config.yaml`. The absence of a `properties` section means no property validation will be done.
- Currently supports `string`, `integer`, `double`, `boolean`, `list`, and `map`. If I'm missing any common JSON objects let me know.
- Unit tests for new code.

### I have verified that:

<!-- Ensure all of these boxes are checked -->
- [x] All related unit tests have been updated/created
- [x] Integration tests are passing

### Additional Notes

<!-- Put any other additional notes here for reviewers -->
The new config section should look like:

```yaml
properties:
  - name: uniqueID
    type: string
  - name: myProperty
    type: list
```
