### PR TITLE
Add EmailModule Unit Tests and Fix Bug

### DIFF
--- a/application/src/main/java/com/sanction/thunder/email/EmailModule.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailModule.java
@@ -61,7 +61,7 @@ public class EmailModule {
   @Named("successHtml")
   String provideSuccessHtml() {
     if (successHtmlPath != null) {
-      readFileFromPath(successHtmlPath);
+      return readFileFromPath(successHtmlPath);
     }
 
     return readFileAsResources(DEFAULT_SUCCESS_PAGE);

--- a/application/src/main/resources/success.html
+++ b/application/src/main/resources/success.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<div class="alert alert-success">
+<html>
+  <div class="alert alert-success">
     <div align="center"><strong>Success!</strong><br>Your account has been verified.</div>
-</div>
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
+  </div>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" />
 </html>

--- a/application/src/main/resources/verification.html
+++ b/application/src/main/resources/verification.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<h1> Welcome to Pilot! </h1>
-<p> Click the below link to verify your account. </p>
-<a href="http://thunder.sanctionco.com/verify?email=%s&token=%s&response_type=html">Click here to verify your account!</a>
+<html>
+  <h1>Welcome!</h1>
+  <p>Click the below link to verify your account.</p>
+  <a href="http://thunder.sanctionco.com/verify?email=%s&token=%s&response_type=html">Click here to verify your account!</a>
 </html>

--- a/application/src/main/resources/verification.txt
+++ b/application/src/main/resources/verification.txt
@@ -1,2 +1,4 @@
+Welcome!
+
 Visit the below address to verify your account.
 http://thunder.sanctionco.com/verify?email=%s&token=%s&response_type=html

--- a/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
@@ -1,0 +1,87 @@
+package com.sanction.thunder.email;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EmailModuleTest {
+  private static final EmailConfiguration EMAIL_CONFIG = mock(EmailConfiguration.class);
+
+  @BeforeClass
+  public static void setup() {
+    when(EMAIL_CONFIG.getEndpoint()).thenReturn("http://localhost:4567");
+    when(EMAIL_CONFIG.getRegion()).thenReturn("us-east-1");
+    when(EMAIL_CONFIG.getFromAddress()).thenReturn("test@test.com");
+  }
+
+  @Test
+  public void testProvideSuccessHtmlDefault() throws IOException {
+    when(EMAIL_CONFIG.getSuccessHtmlPath()).thenReturn(null);
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(Resources.getResource("success.html"), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideSuccessHtml());
+  }
+
+  @Test
+  public void testProvideSuccessHtmlCustom() throws Exception {
+    when(EMAIL_CONFIG.getSuccessHtmlPath()).thenReturn(new File(
+        Resources.getResource("fixtures/success-page.html").toURI()).getAbsolutePath());
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(Resources.getResource("fixtures/success-page.html"), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideSuccessHtml());
+  }
+
+  @Test
+  public void testProvideVerificationHtmlDefault() throws IOException {
+    when(EMAIL_CONFIG.getVerificationHtmlPath()).thenReturn(null);
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(Resources.getResource("verification.html"), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideVerificationHtml());
+  }
+
+  @Test
+  public void testProvideVerificationHtmlCustom() throws Exception {
+    when(EMAIL_CONFIG.getVerificationHtmlPath()).thenReturn(new File(
+        Resources.getResource("fixtures/verification-email.html").toURI()).getAbsolutePath());
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(Resources.getResource("fixtures/verification-email.html"), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideVerificationHtml());
+  }
+
+  @Test
+  public void testProvideVerificationTextDefault() throws IOException {
+    when(EMAIL_CONFIG.getVerificationTextPath()).thenReturn(null);
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(Resources.getResource("verification.txt"), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideVerificationText());
+  }
+
+  @Test
+  public void testProvideVerificationTextCustom() throws Exception {
+    when(EMAIL_CONFIG.getVerificationTextPath()).thenReturn(new File(
+        Resources.getResource("fixtures/verification-email.txt").toURI()).getAbsolutePath());
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(Resources.getResource("fixtures/verification-email.txt"), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideVerificationText());
+  }
+}

--- a/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
@@ -2,11 +2,12 @@ package com.sanction.thunder.email;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -15,6 +16,9 @@ import static org.mockito.Mockito.when;
 public class EmailModuleTest {
   private static final EmailConfiguration EMAIL_CONFIG = mock(EmailConfiguration.class);
 
+  /**
+   * Sets up the EmailConfiguration.
+   */
   @BeforeClass
   public static void setup() {
     when(EMAIL_CONFIG.getEndpoint()).thenReturn("http://localhost:4567");
@@ -28,7 +32,8 @@ public class EmailModuleTest {
 
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 
-    String expected = Resources.toString(Resources.getResource("success.html"), Charsets.UTF_8);
+    String expected = Resources.toString(
+        Resources.getResource("success.html"), Charsets.UTF_8);
     assertEquals(expected, emailModule.provideSuccessHtml());
   }
 
@@ -39,7 +44,8 @@ public class EmailModuleTest {
 
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 
-    String expected = Resources.toString(Resources.getResource("fixtures/success-page.html"), Charsets.UTF_8);
+    String expected = Resources.toString(
+        Resources.getResource("fixtures/success-page.html"), Charsets.UTF_8);
     assertEquals(expected, emailModule.provideSuccessHtml());
   }
 
@@ -49,7 +55,8 @@ public class EmailModuleTest {
 
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 
-    String expected = Resources.toString(Resources.getResource("verification.html"), Charsets.UTF_8);
+    String expected = Resources.toString(
+        Resources.getResource("verification.html"), Charsets.UTF_8);
     assertEquals(expected, emailModule.provideVerificationHtml());
   }
 
@@ -60,7 +67,8 @@ public class EmailModuleTest {
 
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 
-    String expected = Resources.toString(Resources.getResource("fixtures/verification-email.html"), Charsets.UTF_8);
+    String expected = Resources.toString(
+        Resources.getResource("fixtures/verification-email.html"), Charsets.UTF_8);
     assertEquals(expected, emailModule.provideVerificationHtml());
   }
 
@@ -70,7 +78,8 @@ public class EmailModuleTest {
 
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 
-    String expected = Resources.toString(Resources.getResource("verification.txt"), Charsets.UTF_8);
+    String expected = Resources.toString(
+        Resources.getResource("verification.txt"), Charsets.UTF_8);
     assertEquals(expected, emailModule.provideVerificationText());
   }
 
@@ -81,7 +90,8 @@ public class EmailModuleTest {
 
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 
-    String expected = Resources.toString(Resources.getResource("fixtures/verification-email.txt"), Charsets.UTF_8);
+    String expected = Resources.toString(
+        Resources.getResource("fixtures/verification-email.txt"), Charsets.UTF_8);
     assertEquals(expected, emailModule.provideVerificationText());
   }
 }


### PR DESCRIPTION
### This PR addresses:

<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists -->
- Adds unit tests for `EmailModule` to verify custom and default HTML.
- Fixes bug in `provideSuccessHtml()` (missing `return` statement)

### I have verified that:

<!-- Ensure all of these boxes are checked -->
- [x] All related unit tests have been updated/created
- [x] Integration tests are passing

### Additional Notes

<!-- Put any other additional notes here for reviewers -->
