### PR TITLE
Enable more Email Configuration Options

### DIFF
--- a/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
@@ -39,9 +39,9 @@ public class EmailConfiguration {
   /* Optional configuration options */
 
   @JsonProperty("messageOptions")
-  private final MessageOptions messageOptions = null;
+  private final MessageOptionsConfiguration messageOptions = null;
 
-  public MessageOptions getMessageOptions() {
+  public MessageOptionsConfiguration getMessageOptions() {
     return messageOptions;
   }
 }

--- a/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
@@ -41,7 +41,7 @@ public class EmailConfiguration {
   @JsonProperty("messageOptions")
   private final MessageOptionsConfiguration messageOptions = null;
 
-  public MessageOptionsConfiguration getMessageOptions() {
+  public MessageOptionsConfiguration getMessageOptionsConfiguration() {
     return messageOptions;
   }
 }

--- a/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailConfiguration.java
@@ -38,24 +38,10 @@ public class EmailConfiguration {
 
   /* Optional configuration options */
 
-  @JsonProperty("successHtml")
-  private final String successHtmlPath = null;
+  @JsonProperty("messageOptions")
+  private final MessageOptions messageOptions = null;
 
-  public String getSuccessHtmlPath() {
-    return successHtmlPath;
-  }
-
-  @JsonProperty("verificationHtml")
-  private final String verificationHtmlPath = null;
-
-  public String getVerificationHtmlPath() {
-    return verificationHtmlPath;
-  }
-
-  @JsonProperty("verificationText")
-  private final String verificationTextPath = null;
-
-  public String getVerificationTextPath() {
-    return verificationTextPath;
+  public MessageOptions getMessageOptions() {
+    return messageOptions;
   }
 }

--- a/application/src/main/java/com/sanction/thunder/email/EmailModule.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailModule.java
@@ -49,7 +49,7 @@ public class EmailModule {
     this.region = Objects.requireNonNull(emailConfiguration.getRegion());
     this.fromAddress = Objects.requireNonNull(emailConfiguration.getFromAddress());
 
-    this.messageOptionsConfiguration = emailConfiguration.getMessageOptions();
+    this.messageOptionsConfiguration = emailConfiguration.getMessageOptionsConfiguration();
   }
 
   @Singleton
@@ -94,7 +94,8 @@ public class EmailModule {
   @Provides
   @Named("successHtml")
   String provideSuccessHtml() {
-    if (messageOptionsConfiguration != null && messageOptionsConfiguration.getSuccessHtmlFilePath() != null) {
+    if (messageOptionsConfiguration != null
+        && messageOptionsConfiguration.getSuccessHtmlFilePath() != null) {
       return readFileFromPath(messageOptionsConfiguration.getSuccessHtmlFilePath());
     }
 
@@ -105,7 +106,8 @@ public class EmailModule {
   @Provides
   @Named("bodyHtml")
   String provideBodyHtml() {
-    if (messageOptionsConfiguration != null  && messageOptionsConfiguration.getBodyHtmlFilePath() != null) {
+    if (messageOptionsConfiguration != null
+        && messageOptionsConfiguration.getBodyHtmlFilePath() != null) {
       return readFileFromPath(messageOptionsConfiguration.getBodyHtmlFilePath());
     }
 
@@ -116,7 +118,8 @@ public class EmailModule {
   @Provides
   @Named("bodyText")
   String provideBodyText() {
-    if (messageOptionsConfiguration != null && messageOptionsConfiguration.getBodyTextFilePath() != null) {
+    if (messageOptionsConfiguration != null
+        && messageOptionsConfiguration.getBodyTextFilePath() != null) {
       return readFileFromPath(messageOptionsConfiguration.getBodyTextFilePath());
     }
 
@@ -124,10 +127,10 @@ public class EmailModule {
   }
 
   /**
-   * Reads a file as a <code>String</code> from a path.
+   * Reads a file as a {@code String} from a path.
    *
    * @param path The path to the file to be read.
-   * @return The file contents as a <code>String</code>.
+   * @return The file contents as a {@code String}.
    */
   private String readFileFromPath(String path) {
     try {
@@ -145,7 +148,7 @@ public class EmailModule {
    * Reads a file from the resources folder.
    *
    * @param fileName The name of the file to be read.
-   * @return The contents of the file as a <code>String</code>.
+   * @return The contents of the file as a {@code String}.
    */
   private String readFileAsResources(String fileName) {
     try {

--- a/application/src/main/java/com/sanction/thunder/email/EmailModule.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailModule.java
@@ -31,9 +31,8 @@ public class EmailModule {
   private final String endpoint;
   private final String region;
   private final String fromAddress;
-  private final String successHtmlPath;
-  private final String verificationHtmlPath;
-  private final String verificationTextPath;
+
+  private final MessageOptions messageOptions;
 
   /**
    * Constructs a new EmailModule object.
@@ -47,9 +46,7 @@ public class EmailModule {
     this.region = Objects.requireNonNull(emailConfiguration.getRegion());
     this.fromAddress = Objects.requireNonNull(emailConfiguration.getFromAddress());
 
-    this.successHtmlPath = emailConfiguration.getSuccessHtmlPath();
-    this.verificationHtmlPath = emailConfiguration.getVerificationHtmlPath();
-    this.verificationTextPath = emailConfiguration.getVerificationTextPath();
+    this.messageOptions = emailConfiguration.getMessageOptions();
   }
 
   @Singleton
@@ -70,8 +67,8 @@ public class EmailModule {
   @Provides
   @Named("successHtml")
   String provideSuccessHtml() {
-    if (successHtmlPath != null) {
-      return readFileFromPath(successHtmlPath);
+    if (messageOptions != null && messageOptions.getSuccessHtmlFilePath() != null) {
+      return readFileFromPath(messageOptions.getSuccessHtmlFilePath());
     }
 
     return readFileAsResources(DEFAULT_SUCCESS_PAGE);
@@ -81,8 +78,8 @@ public class EmailModule {
   @Provides
   @Named("verificationHtml")
   String provideVerificationHtml() {
-    if (verificationHtmlPath != null) {
-      return readFileFromPath(verificationHtmlPath);
+    if (messageOptions != null  && messageOptions.getBodyHtmlFilePath() != null) {
+      return readFileFromPath(messageOptions.getBodyHtmlFilePath());
     }
 
     return readFileAsResources(DEFAULT_VERIFICATION_HTML);
@@ -92,8 +89,8 @@ public class EmailModule {
   @Provides
   @Named("verificationText")
   String provideVerificationText() {
-    if (verificationTextPath != null) {
-      return readFileFromPath(verificationTextPath);
+    if (messageOptions != null && messageOptions.getBodyTextFilePath() != null) {
+      return readFileFromPath(messageOptions.getBodyTextFilePath());
     }
 
     return readFileAsResources(DEFAULT_VERIFICATION_TEXT);

--- a/application/src/main/java/com/sanction/thunder/email/EmailModule.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailModule.java
@@ -26,10 +26,10 @@ import javax.inject.Singleton;
 @Module
 public class EmailModule {
   private static final String DEFAULT_SUBJECT = "Account Verification";
-  private static final String DEFAULT_VERIFICATION_HTML = "verification.html";
-  private static final String DEFAULT_VERIFICATION_TEXT = "verification.txt";
+  private static final String DEFAULT_BODY_HTML_FILE = "verification.html";
+  private static final String DEFAULT_BODY_TEXT_FILE = "verification.txt";
   private static final String DEFAULT_PLACEHOLDER = "CODEGEN-URL";
-  private static final String DEFAULT_SUCCESS_PAGE = "success.html";
+  private static final String DEFAULT_SUCCESS_HTML_FILE = "success.html";
 
   private final String endpoint;
   private final String region;
@@ -73,16 +73,11 @@ public class EmailModule {
                                        @Named("successHtml") String successHtml) {
     if (messageOptionsConfiguration == null) {
       return new MessageOptions(
-          DEFAULT_SUBJECT,
-          bodyHtml,
-          bodyText,
-          DEFAULT_PLACEHOLDER,
-          successHtml);
+          DEFAULT_SUBJECT, bodyHtml, bodyText, DEFAULT_PLACEHOLDER, successHtml);
     }
 
     return new MessageOptions(
-        Optional.ofNullable(messageOptionsConfiguration.getSubject())
-            .orElse(DEFAULT_SUBJECT),
+        Optional.ofNullable(messageOptionsConfiguration.getSubject()).orElse(DEFAULT_SUBJECT),
         bodyHtml,
         bodyText,
         Optional.ofNullable(messageOptionsConfiguration.getUrlPlaceholderString())
@@ -99,7 +94,7 @@ public class EmailModule {
       return readFileFromPath(messageOptionsConfiguration.getSuccessHtmlFilePath());
     }
 
-    return readFileAsResources(DEFAULT_SUCCESS_PAGE);
+    return readFileAsResources(DEFAULT_SUCCESS_HTML_FILE);
   }
 
   @Singleton
@@ -111,7 +106,7 @@ public class EmailModule {
       return readFileFromPath(messageOptionsConfiguration.getBodyHtmlFilePath());
     }
 
-    return readFileAsResources(DEFAULT_VERIFICATION_HTML);
+    return readFileAsResources(DEFAULT_BODY_HTML_FILE);
   }
 
   @Singleton
@@ -123,7 +118,7 @@ public class EmailModule {
       return readFileFromPath(messageOptionsConfiguration.getBodyTextFilePath());
     }
 
-    return readFileAsResources(DEFAULT_VERIFICATION_TEXT);
+    return readFileAsResources(DEFAULT_BODY_TEXT_FILE);
   }
 
   /**

--- a/application/src/main/java/com/sanction/thunder/email/MessageOptions.java
+++ b/application/src/main/java/com/sanction/thunder/email/MessageOptions.java
@@ -1,0 +1,84 @@
+package com.sanction.thunder.email;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+import java.util.StringJoiner;
+
+/**
+ * Holds optional Email message configuration.
+ */
+public class MessageOptions {
+  private final String subject;
+  private final String bodyHtmlFilePath;
+  private final String bodyTextFilePath;
+  private final String urlPlaceholderString;
+  private final String successHtmlFilePath;
+
+  public MessageOptions(@JsonProperty("subject") String subject,
+                        @JsonProperty("bodyHtmlFile") String bodyHtmlFilePath,
+                        @JsonProperty("bodyTextFile") String bodyTextFilePath,
+                        @JsonProperty("urlPlaceholderString") String urlPlaceholderString,
+                        @JsonProperty("successHtmlFile") String successHtmlFilePath) {
+    this.subject = subject;
+    this.bodyHtmlFilePath = bodyHtmlFilePath;
+    this.bodyTextFilePath = bodyTextFilePath;
+    this.urlPlaceholderString = urlPlaceholderString;
+    this.successHtmlFilePath = successHtmlFilePath;
+  }
+
+  public String getSubject() {
+    return subject;
+  }
+
+  public String getBodyHtmlFilePath() {
+    return bodyHtmlFilePath;
+  }
+
+  public String getBodyTextFilePath() {
+    return bodyTextFilePath;
+  }
+
+  public String getUrlPlaceholderString() {
+    return urlPlaceholderString;
+  }
+
+  public String getSuccessHtmlFilePath() {
+    return successHtmlFilePath;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof MessageOptions)) {
+      return false;
+    }
+
+    MessageOptions other = (MessageOptions) obj;
+    return Objects.equals(this.subject, other.subject)
+        && Objects.equals(this.bodyHtmlFilePath, other.bodyHtmlFilePath)
+        && Objects.equals(this.bodyTextFilePath, other.bodyTextFilePath)
+        && Objects.equals(this.urlPlaceholderString, other.urlPlaceholderString)
+        && Objects.equals(this.successHtmlFilePath, other.successHtmlFilePath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        subject, bodyHtmlFilePath, bodyTextFilePath, urlPlaceholderString, successHtmlFilePath);
+  }
+
+  @Override
+  public String toString() {
+    return new StringJoiner(", ", "MessageOptions [", "]")
+        .add(String.format("subject=%s", subject))
+        .add(String.format("bodyHtmlFilePath=%s", bodyHtmlFilePath))
+        .add(String.format("bodyTextFilePath=%s", bodyTextFilePath))
+        .add(String.format("urlPlaceholderString=%s", urlPlaceholderString))
+        .add(String.format("successHtmlFilePath=%s", successHtmlFilePath))
+        .toString();
+  }
+}

--- a/application/src/main/java/com/sanction/thunder/email/MessageOptions.java
+++ b/application/src/main/java/com/sanction/thunder/email/MessageOptions.java
@@ -6,45 +6,45 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 /**
- * Holds optional Email message configuration.
+ * Holds optional Email message configuration such as email content and success HTML.
  */
 public class MessageOptions {
   private final String subject;
-  private final String bodyHtmlFilePath;
-  private final String bodyTextFilePath;
+  private final String bodyHtml;
+  private final String bodyText;
   private final String urlPlaceholderString;
-  private final String successHtmlFilePath;
+  private final String successHtml;
 
   public MessageOptions(@JsonProperty("subject") String subject,
-                        @JsonProperty("bodyHtmlFile") String bodyHtmlFilePath,
-                        @JsonProperty("bodyTextFile") String bodyTextFilePath,
+                        @JsonProperty("bodyHtmlFile") String bodyHtml,
+                        @JsonProperty("bodyTextFile") String bodyText,
                         @JsonProperty("urlPlaceholderString") String urlPlaceholderString,
-                        @JsonProperty("successHtmlFile") String successHtmlFilePath) {
+                        @JsonProperty("successHtmlFile") String successHtml) {
     this.subject = subject;
-    this.bodyHtmlFilePath = bodyHtmlFilePath;
-    this.bodyTextFilePath = bodyTextFilePath;
+    this.bodyHtml = bodyHtml;
+    this.bodyText = bodyText;
     this.urlPlaceholderString = urlPlaceholderString;
-    this.successHtmlFilePath = successHtmlFilePath;
+    this.successHtml = successHtml;
   }
 
   public String getSubject() {
     return subject;
   }
 
-  public String getBodyHtmlFilePath() {
-    return bodyHtmlFilePath;
+  public String getBodyHtml() {
+    return bodyHtml;
   }
 
-  public String getBodyTextFilePath() {
-    return bodyTextFilePath;
+  public String getBodyText() {
+    return bodyText;
   }
 
   public String getUrlPlaceholderString() {
     return urlPlaceholderString;
   }
 
-  public String getSuccessHtmlFilePath() {
-    return successHtmlFilePath;
+  public String getSuccessHtml() {
+    return successHtml;
   }
 
   @Override
@@ -59,26 +59,26 @@ public class MessageOptions {
 
     MessageOptions other = (MessageOptions) obj;
     return Objects.equals(this.subject, other.subject)
-        && Objects.equals(this.bodyHtmlFilePath, other.bodyHtmlFilePath)
-        && Objects.equals(this.bodyTextFilePath, other.bodyTextFilePath)
+        && Objects.equals(this.bodyHtml, other.bodyHtml)
+        && Objects.equals(this.bodyText, other.bodyText)
         && Objects.equals(this.urlPlaceholderString, other.urlPlaceholderString)
-        && Objects.equals(this.successHtmlFilePath, other.successHtmlFilePath);
+        && Objects.equals(this.successHtml, other.successHtml);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        subject, bodyHtmlFilePath, bodyTextFilePath, urlPlaceholderString, successHtmlFilePath);
+        subject, bodyHtml, bodyText, urlPlaceholderString, successHtml);
   }
 
   @Override
   public String toString() {
     return new StringJoiner(", ", "MessageOptions [", "]")
         .add(String.format("subject=%s", subject))
-        .add(String.format("bodyHtmlFilePath=%s", bodyHtmlFilePath))
-        .add(String.format("bodyTextFilePath=%s", bodyTextFilePath))
+        .add(String.format("bodyHtml=%s", bodyHtml))
+        .add(String.format("bodyText=%s", bodyText))
         .add(String.format("urlPlaceholderString=%s", urlPlaceholderString))
-        .add(String.format("successHtmlFilePath=%s", successHtmlFilePath))
+        .add(String.format("successHtml=%s", successHtml))
         .toString();
   }
 }

--- a/application/src/main/java/com/sanction/thunder/email/MessageOptions.java
+++ b/application/src/main/java/com/sanction/thunder/email/MessageOptions.java
@@ -15,6 +15,16 @@ public class MessageOptions {
   private final String urlPlaceholderString;
   private final String successHtml;
 
+  /**
+   * Constructs a new MessageOptions instance.
+   *
+   * @param subject The subject of the email message.
+   * @param bodyHtml The body of the email message in HTML form.
+   * @param bodyText The body of the email message in plaintext form.
+   * @param urlPlaceholderString The placeholder string found in the body that should be replaced
+   *                             by a custom URL on each message request.
+   * @param successHtml The HTML contents to display on successful verification.
+   */
   public MessageOptions(@JsonProperty("subject") String subject,
                         @JsonProperty("bodyHtmlFile") String bodyHtml,
                         @JsonProperty("bodyTextFile") String bodyText,

--- a/application/src/main/java/com/sanction/thunder/email/MessageOptionsConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/email/MessageOptionsConfiguration.java
@@ -1,0 +1,43 @@
+package com.sanction.thunder.email;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+class MessageOptionsConfiguration {
+
+  /* Optional configuration options */
+
+  @JsonProperty("subject")
+  private final String subject = null;
+
+  String getSubject() {
+    return subject;
+  }
+
+  @JsonProperty("bodyHtmlFilePath")
+  private final String bodyHtmlFilePath = null;
+
+  String getBodyHtmlFilePath() {
+    return bodyHtmlFilePath;
+  }
+
+  @JsonProperty("bodyTextFilePath")
+  private final String bodyTextFilePath = null;
+
+  String getBodyTextFilePath() {
+    return bodyTextFilePath;
+  }
+
+  @JsonProperty("urlPlaceholderString")
+  private final String urlPlaceholderString = null;
+
+  String getUrlPlaceholderString() {
+    return urlPlaceholderString;
+  }
+
+  @JsonProperty("successHtmlFilePath")
+  private final String successHtmlFilePath = null;
+
+  String getSuccessHtmlFilePath() {
+    return successHtmlFilePath;
+  }
+}

--- a/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
@@ -69,7 +69,6 @@ public class VerificationResource {
                               MessageOptions messageOptions) {
     this.usersDao = Objects.requireNonNull(usersDao);
     this.emailService = Objects.requireNonNull(emailService);
-
     this.messageOptions = Objects.requireNonNull(messageOptions);
 
     // Set up metrics

--- a/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
@@ -20,7 +20,6 @@ import java.util.Objects;
 import java.util.UUID;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;

--- a/application/src/main/java/com/sanction/thunder/util/EmailUtilities.java
+++ b/application/src/main/java/com/sanction/thunder/util/EmailUtilities.java
@@ -10,8 +10,6 @@ import org.slf4j.LoggerFactory;
 public class EmailUtilities {
   private static final Logger LOG = LoggerFactory.getLogger(EmailUtilities.class);
 
-  private static final String URL_PLACEHOLDER = "CODEGEN-URL";
-
   /**
    * Replaces the placeholder inside the given file contents with the given URL.
    *
@@ -19,12 +17,12 @@ public class EmailUtilities {
    * @param url The URL to insert in place of the placeholder.
    * @return A string with modified file contents including the URL.
    */
-  public static String replaceUrlPlaceholder(String fileContents, String url) {
-    if (!fileContents.contains(URL_PLACEHOLDER)) {
-      LOG.warn("The email file contents do not contain any instances of the URL placeholder {}",
-          URL_PLACEHOLDER);
+  public static String replaceUrlPlaceholder(String fileContents, String placeholder, String url) {
+    if (!fileContents.contains(placeholder)) {
+      LOG.warn("The file contents do not contain any instances of the URL placeholder {}",
+          placeholder);
     }
 
-    return fileContents.replaceAll(URL_PLACEHOLDER, url);
+    return fileContents.replaceAll(placeholder, url);
   }
 }

--- a/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
@@ -58,7 +58,7 @@ class ThunderApplicationTest {
     when(emailConfig.getEndpoint()).thenReturn("http://localhost");
     when(emailConfig.getRegion()).thenReturn("us-east-1");
     when(emailConfig.getFromAddress()).thenReturn("testAddress@test.com");
-    when(emailConfig.getMessageOptions()).thenReturn(null);
+    when(emailConfig.getMessageOptionsConfiguration()).thenReturn(null);
 
     // ThunderConfiguration NotNull fields
     when(config.getApprovedKeys()).thenReturn(new ArrayList<>());

--- a/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderApplicationTest.java
@@ -58,9 +58,7 @@ class ThunderApplicationTest {
     when(emailConfig.getEndpoint()).thenReturn("http://localhost");
     when(emailConfig.getRegion()).thenReturn("us-east-1");
     when(emailConfig.getFromAddress()).thenReturn("testAddress@test.com");
-    when(emailConfig.getSuccessHtmlPath()).thenReturn(null);
-    when(emailConfig.getVerificationHtmlPath()).thenReturn(null);
-    when(emailConfig.getVerificationTextPath()).thenReturn(null);
+    when(emailConfig.getMessageOptions()).thenReturn(null);
 
     // ThunderConfiguration NotNull fields
     when(config.getApprovedKeys()).thenReturn(new ArrayList<>());

--- a/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
@@ -41,7 +41,7 @@ class ThunderConfigurationTest {
 
     assertEquals(
         new MessageOptions("Test Subject", "test-body.html", "test-body.txt", "TEST-PLACEHOLDER", "test-success-page.html"),
-        configuration.getEmailConfiguration().getMessageOptions());
+        configuration.getEmailConfiguration().getMessageOptionsConfiguration());
 
     assertEquals(1, configuration.getApprovedKeys().size());
     assertEquals(

--- a/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 
 import com.sanction.thunder.authentication.Key;
-import com.sanction.thunder.email.MessageOptions;
 import com.sanction.thunder.validation.PropertyValidationRule;
 
 import io.dropwizard.configuration.YamlConfigurationFactory;
@@ -19,6 +18,7 @@ import javax.validation.Validator;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class ThunderConfigurationTest {
   private final ObjectMapper mapper = Jackson.newObjectMapper();
@@ -39,9 +39,7 @@ class ThunderConfigurationTest {
     assertEquals("test-region-2", configuration.getEmailConfiguration().getRegion());
     assertEquals("test@sanctionco.com", configuration.getEmailConfiguration().getFromAddress());
 
-    assertEquals(
-        new MessageOptions("Test Subject", "test-body.html", "test-body.txt", "TEST-PLACEHOLDER", "test-success-page.html"),
-        configuration.getEmailConfiguration().getMessageOptionsConfiguration());
+    assertNotNull(configuration.getEmailConfiguration().getMessageOptionsConfiguration());
 
     assertEquals(1, configuration.getApprovedKeys().size());
     assertEquals(

--- a/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
+++ b/application/src/test/java/com/sanction/thunder/ThunderConfigurationTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 
 import com.sanction.thunder.authentication.Key;
+import com.sanction.thunder.email.MessageOptions;
 import com.sanction.thunder.validation.PropertyValidationRule;
 
 import io.dropwizard.configuration.YamlConfigurationFactory;
@@ -38,12 +39,9 @@ class ThunderConfigurationTest {
     assertEquals("test-region-2", configuration.getEmailConfiguration().getRegion());
     assertEquals("test@sanctionco.com", configuration.getEmailConfiguration().getFromAddress());
 
-    assertEquals("test-success-page.html",
-        configuration.getEmailConfiguration().getSuccessHtmlPath());
-    assertEquals("test-verification-email.html",
-        configuration.getEmailConfiguration().getVerificationHtmlPath());
-    assertEquals("test-verification-email.txt",
-        configuration.getEmailConfiguration().getVerificationTextPath());
+    assertEquals(
+        new MessageOptions("Test Subject", "test-body.html", "test-body.txt", "TEST-PLACEHOLDER", "test-success-page.html"),
+        configuration.getEmailConfiguration().getMessageOptions());
 
     assertEquals(1, configuration.getApprovedKeys().size());
     assertEquals(

--- a/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
@@ -1,102 +1,184 @@
-//package com.sanction.thunder.email;
-//
-//import com.google.common.base.Charsets;
-//import com.google.common.io.Resources;
-//
-//import java.io.File;
-//import java.io.IOException;
-//
-//import org.junit.jupiter.api.BeforeAll;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.when;
-//
-//class EmailModuleTest {
-//  private static final EmailConfiguration EMAIL_CONFIG = mock(EmailConfiguration.class);
-//
-//  @BeforeAll
-//  static void setup() {
-//    when(EMAIL_CONFIG.getEndpoint()).thenReturn("http://localhost:4567");
-//    when(EMAIL_CONFIG.getRegion()).thenReturn("us-east-1");
-//    when(EMAIL_CONFIG.getFromAddress()).thenReturn("test@test.com");
-//  }
-//
-//  @BeforeEach
-//  void reset() {
-//    when(EMAIL_CONFIG.getMessageOptions()).thenReturn(
-//        new MessageOptions(null, null, null, null, null));
-//  }
-//
-//  @Test
-//  void testProvideSuccessHtmlDefault() throws IOException {
-//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-//
-//    String expected = Resources.toString(
-//        Resources.getResource("success.html"), Charsets.UTF_8);
-//    assertEquals(expected, emailModule.provideSuccessHtml());
-//  }
-//
-//  @Test
-//  void testProvideSuccessHtmlCustom() throws Exception {
-//    when(EMAIL_CONFIG.getMessageOptions())
-//        .thenReturn(new MessageOptions(null, null, null, null,
-//            new File(Resources.getResource("fixtures/success-page.html").toURI()).getAbsolutePath()));
-//
-//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-//
-//    String expected = Resources.toString(
-//        Resources.getResource("fixtures/success-page.html"), Charsets.UTF_8);
-//    assertEquals(expected, emailModule.provideSuccessHtml());
-//  }
-//
-//  @Test
-//  void testProvideVerificationHtmlDefault() throws IOException {
-//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-//
-//    String expected = Resources.toString(
-//        Resources.getResource("verification.html"), Charsets.UTF_8);
-//    assertEquals(expected, emailModule.provideBodyHtml());
-//  }
-//
-//  @Test
-//  void testProvideVerificationHtmlCustom() throws Exception {
-//    String path = new File(Resources.getResource(
-//        "fixtures/verification-email.html").toURI()).getAbsolutePath();
-//
-//    when(EMAIL_CONFIG.getMessageOptions())
-//        .thenReturn(new MessageOptions(null, path, null, null, null));
-//
-//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-//
-//    String expected = Resources.toString(
-//        Resources.getResource("fixtures/verification-email.html"), Charsets.UTF_8);
-//    assertEquals(expected, emailModule.provideBodyHtml());
-//  }
-//
-//  @Test
-//  void testProvideVerificationTextDefault() throws IOException {
-//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-//
-//    String expected = Resources.toString(
-//        Resources.getResource("verification.txt"), Charsets.UTF_8);
-//    assertEquals(expected, emailModule.provideBodyText());
-//  }
-//
-//  @Test
-//  void testProvideVerificationTextCustom() throws Exception {
-//    String path = new File(
-//        Resources.getResource("fixtures/verification-email.txt").toURI()).getAbsolutePath();
-//
-//    when(EMAIL_CONFIG.getMessageOptions())
-//        .thenReturn(new MessageOptions(null, null, path, null, null));
-//
-//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-//
-//    String expected = Resources.toString(
-//        Resources.getResource("fixtures/verification-email.txt"), Charsets.UTF_8);
-//    assertEquals(expected, emailModule.provideBodyText());
-//  }
-//}
+package com.sanction.thunder.email;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EmailModuleTest {
+  private static final String DEFAULT_SUCCESS_HTML_RESOURCE_FILE = "success.html";
+  private static final String DEFAULT_BODY_HTML_RESOURCE_FILE = "verification.html";
+  private static final String DEFAULT_BODY_TEXT_RESOURCE_FILE = "verification.txt";
+
+  private static final String CUSTOM_SUCCESS_HTML_RESOURCE_FILE = "fixtures/success-page.html";
+  private static final String CUSTOM_BODY_HTML_RESOURCE_FILE = "fixtures/verification-email.html";
+  private static final String CUSTOM_BODY_TEXT_RESOURCE_FILE = "fixtures/verification-email.txt";
+
+  private static final EmailConfiguration EMAIL_CONFIG = mock(EmailConfiguration.class);
+  private static final MessageOptionsConfiguration OPTIONS_CONFIG
+      = mock(MessageOptionsConfiguration.class);
+
+  @BeforeAll
+  static void setup() throws Exception {
+    when(EMAIL_CONFIG.getEndpoint()).thenReturn("http://localhost:4567");
+    when(EMAIL_CONFIG.getRegion()).thenReturn("us-east-1");
+    when(EMAIL_CONFIG.getFromAddress()).thenReturn("test@test.com");
+
+    String customSuccessHtmlFilePath = new File(
+        Resources.getResource(CUSTOM_SUCCESS_HTML_RESOURCE_FILE).toURI()).getAbsolutePath();
+    String customBodyHtmlFilePath = new File(
+        Resources.getResource(CUSTOM_BODY_HTML_RESOURCE_FILE).toURI()).getAbsolutePath();
+    String customBodyTextFilePath = new File(
+        Resources.getResource(CUSTOM_BODY_TEXT_RESOURCE_FILE).toURI()).getAbsolutePath();
+
+    when(OPTIONS_CONFIG.getBodyHtmlFilePath()).thenReturn(customBodyHtmlFilePath);
+    when(OPTIONS_CONFIG.getBodyTextFilePath()).thenReturn(customBodyTextFilePath);
+    when(OPTIONS_CONFIG.getSuccessHtmlFilePath()).thenReturn(customSuccessHtmlFilePath);
+  }
+
+  /* provideMessageOptions() */
+
+  @Test
+  void testProvideMessageOptionsNull() {
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(null);
+
+    MessageOptions expected = new MessageOptions(
+        "Account Verification", "bodyHtml", "bodyText", "CODEGEN-URL", "successHtml");
+
+    MessageOptions result = new EmailModule(EMAIL_CONFIG)
+        .provideMessageOptions("bodyHtml", "bodyText", "successHtml");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testProvideMessageOptionsCustom() {
+    when(OPTIONS_CONFIG.getSubject()).thenReturn("Test Subject");
+    when(OPTIONS_CONFIG.getUrlPlaceholderString()).thenReturn("Test Placeholder");
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(OPTIONS_CONFIG);
+
+    MessageOptions expected = new MessageOptions(
+        "Test Subject", "bodyHtml", "bodyText", "Test Placeholder", "successHtml");
+
+    MessageOptions result = new EmailModule(EMAIL_CONFIG)
+        .provideMessageOptions("bodyHtml", "bodyText", "successHtml");
+
+    assertEquals(expected, result);
+  }
+
+  /* provideSuccessHtml() */
+
+  @Test
+  void testProvideSuccessHtmlNullOptions() throws IOException {
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(null);
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(
+        Resources.getResource(DEFAULT_SUCCESS_HTML_RESOURCE_FILE), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideSuccessHtml());
+  }
+
+  @Test
+  void testProvideSuccessHtmlDefault() throws IOException {
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration())
+        .thenReturn(new MessageOptionsConfiguration());
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(
+        Resources.getResource(DEFAULT_SUCCESS_HTML_RESOURCE_FILE), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideSuccessHtml());
+  }
+
+  @Test
+  void testProvideSuccessHtmlCustom() throws Exception {
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(OPTIONS_CONFIG);
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(
+        Resources.getResource(CUSTOM_SUCCESS_HTML_RESOURCE_FILE), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideSuccessHtml());
+  }
+
+  /* provideBodyHtml() */
+
+  @Test
+  void testProvideBodyHtmlNullOptions() throws IOException {
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(null);
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(
+        Resources.getResource(DEFAULT_BODY_HTML_RESOURCE_FILE), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideBodyHtml());
+  }
+
+  @Test
+  void testProvideBodyHtmlDefault() throws IOException {
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration())
+        .thenReturn(new MessageOptionsConfiguration());
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(
+        Resources.getResource(DEFAULT_BODY_HTML_RESOURCE_FILE), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideBodyHtml());
+  }
+
+  @Test
+  void testProvideBodyHtmlCustom() throws Exception {
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(OPTIONS_CONFIG);
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(
+        Resources.getResource(CUSTOM_BODY_HTML_RESOURCE_FILE), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideBodyHtml());
+  }
+
+  /* provideBodyText() */
+
+  @Test
+  void testProvideBodyTextNullOptions() throws IOException {
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(null);
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(
+        Resources.getResource(DEFAULT_BODY_TEXT_RESOURCE_FILE), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideBodyText());
+  }
+
+  @Test
+  void testProvideBodyTextDefault() throws IOException {
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration())
+        .thenReturn(new MessageOptionsConfiguration());
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(
+        Resources.getResource(DEFAULT_BODY_TEXT_RESOURCE_FILE), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideBodyText());
+  }
+
+  @Test
+  void testProvideBodyTextCustom() throws Exception {
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(OPTIONS_CONFIG);
+
+    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+
+    String expected = Resources.toString(
+        Resources.getResource(CUSTOM_BODY_TEXT_RESOURCE_FILE), Charsets.UTF_8);
+    assertEquals(expected, emailModule.provideBodyText());
+  }
+}

--- a/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -23,10 +24,14 @@ class EmailModuleTest {
     when(EMAIL_CONFIG.getFromAddress()).thenReturn("test@test.com");
   }
 
+  @BeforeEach
+  void reset() {
+    when(EMAIL_CONFIG.getMessageOptions()).thenReturn(
+        new MessageOptions(null, null, null, null, null));
+  }
+
   @Test
   void testProvideSuccessHtmlDefault() throws IOException {
-    when(EMAIL_CONFIG.getSuccessHtmlPath()).thenReturn(null);
-
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 
     String expected = Resources.toString(
@@ -36,8 +41,9 @@ class EmailModuleTest {
 
   @Test
   void testProvideSuccessHtmlCustom() throws Exception {
-    when(EMAIL_CONFIG.getSuccessHtmlPath()).thenReturn(new File(
-        Resources.getResource("fixtures/success-page.html").toURI()).getAbsolutePath());
+    when(EMAIL_CONFIG.getMessageOptions())
+        .thenReturn(new MessageOptions(null, null, null, null,
+            new File(Resources.getResource("fixtures/success-page.html").toURI()).getAbsolutePath()));
 
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 
@@ -48,8 +54,6 @@ class EmailModuleTest {
 
   @Test
   void testProvideVerificationHtmlDefault() throws IOException {
-    when(EMAIL_CONFIG.getVerificationHtmlPath()).thenReturn(null);
-
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 
     String expected = Resources.toString(
@@ -59,8 +63,11 @@ class EmailModuleTest {
 
   @Test
   void testProvideVerificationHtmlCustom() throws Exception {
-    when(EMAIL_CONFIG.getVerificationHtmlPath()).thenReturn(new File(
-        Resources.getResource("fixtures/verification-email.html").toURI()).getAbsolutePath());
+    String path = new File(Resources.getResource(
+        "fixtures/verification-email.html").toURI()).getAbsolutePath();
+
+    when(EMAIL_CONFIG.getMessageOptions())
+        .thenReturn(new MessageOptions(null, path, null, null, null));
 
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 
@@ -71,8 +78,6 @@ class EmailModuleTest {
 
   @Test
   void testProvideVerificationTextDefault() throws IOException {
-    when(EMAIL_CONFIG.getVerificationTextPath()).thenReturn(null);
-
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 
     String expected = Resources.toString(
@@ -82,8 +87,11 @@ class EmailModuleTest {
 
   @Test
   void testProvideVerificationTextCustom() throws Exception {
-    when(EMAIL_CONFIG.getVerificationTextPath()).thenReturn(new File(
-        Resources.getResource("fixtures/verification-email.txt").toURI()).getAbsolutePath());
+    String path = new File(
+        Resources.getResource("fixtures/verification-email.txt").toURI()).getAbsolutePath();
+
+    when(EMAIL_CONFIG.getMessageOptions())
+        .thenReturn(new MessageOptions(null, null, path, null, null));
 
     EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
 

--- a/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
@@ -1,102 +1,102 @@
-package com.sanction.thunder.email;
-
-import com.google.common.base.Charsets;
-import com.google.common.io.Resources;
-
-import java.io.File;
-import java.io.IOException;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-class EmailModuleTest {
-  private static final EmailConfiguration EMAIL_CONFIG = mock(EmailConfiguration.class);
-
-  @BeforeAll
-  static void setup() {
-    when(EMAIL_CONFIG.getEndpoint()).thenReturn("http://localhost:4567");
-    when(EMAIL_CONFIG.getRegion()).thenReturn("us-east-1");
-    when(EMAIL_CONFIG.getFromAddress()).thenReturn("test@test.com");
-  }
-
-  @BeforeEach
-  void reset() {
-    when(EMAIL_CONFIG.getMessageOptions()).thenReturn(
-        new MessageOptions(null, null, null, null, null));
-  }
-
-  @Test
-  void testProvideSuccessHtmlDefault() throws IOException {
-    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-
-    String expected = Resources.toString(
-        Resources.getResource("success.html"), Charsets.UTF_8);
-    assertEquals(expected, emailModule.provideSuccessHtml());
-  }
-
-  @Test
-  void testProvideSuccessHtmlCustom() throws Exception {
-    when(EMAIL_CONFIG.getMessageOptions())
-        .thenReturn(new MessageOptions(null, null, null, null,
-            new File(Resources.getResource("fixtures/success-page.html").toURI()).getAbsolutePath()));
-
-    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-
-    String expected = Resources.toString(
-        Resources.getResource("fixtures/success-page.html"), Charsets.UTF_8);
-    assertEquals(expected, emailModule.provideSuccessHtml());
-  }
-
-  @Test
-  void testProvideVerificationHtmlDefault() throws IOException {
-    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-
-    String expected = Resources.toString(
-        Resources.getResource("verification.html"), Charsets.UTF_8);
-    assertEquals(expected, emailModule.provideVerificationHtml());
-  }
-
-  @Test
-  void testProvideVerificationHtmlCustom() throws Exception {
-    String path = new File(Resources.getResource(
-        "fixtures/verification-email.html").toURI()).getAbsolutePath();
-
-    when(EMAIL_CONFIG.getMessageOptions())
-        .thenReturn(new MessageOptions(null, path, null, null, null));
-
-    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-
-    String expected = Resources.toString(
-        Resources.getResource("fixtures/verification-email.html"), Charsets.UTF_8);
-    assertEquals(expected, emailModule.provideVerificationHtml());
-  }
-
-  @Test
-  void testProvideVerificationTextDefault() throws IOException {
-    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-
-    String expected = Resources.toString(
-        Resources.getResource("verification.txt"), Charsets.UTF_8);
-    assertEquals(expected, emailModule.provideVerificationText());
-  }
-
-  @Test
-  void testProvideVerificationTextCustom() throws Exception {
-    String path = new File(
-        Resources.getResource("fixtures/verification-email.txt").toURI()).getAbsolutePath();
-
-    when(EMAIL_CONFIG.getMessageOptions())
-        .thenReturn(new MessageOptions(null, null, path, null, null));
-
-    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-
-    String expected = Resources.toString(
-        Resources.getResource("fixtures/verification-email.txt"), Charsets.UTF_8);
-    assertEquals(expected, emailModule.provideVerificationText());
-  }
-}
+//package com.sanction.thunder.email;
+//
+//import com.google.common.base.Charsets;
+//import com.google.common.io.Resources;
+//
+//import java.io.File;
+//import java.io.IOException;
+//
+//import org.junit.jupiter.api.BeforeAll;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.when;
+//
+//class EmailModuleTest {
+//  private static final EmailConfiguration EMAIL_CONFIG = mock(EmailConfiguration.class);
+//
+//  @BeforeAll
+//  static void setup() {
+//    when(EMAIL_CONFIG.getEndpoint()).thenReturn("http://localhost:4567");
+//    when(EMAIL_CONFIG.getRegion()).thenReturn("us-east-1");
+//    when(EMAIL_CONFIG.getFromAddress()).thenReturn("test@test.com");
+//  }
+//
+//  @BeforeEach
+//  void reset() {
+//    when(EMAIL_CONFIG.getMessageOptions()).thenReturn(
+//        new MessageOptions(null, null, null, null, null));
+//  }
+//
+//  @Test
+//  void testProvideSuccessHtmlDefault() throws IOException {
+//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+//
+//    String expected = Resources.toString(
+//        Resources.getResource("success.html"), Charsets.UTF_8);
+//    assertEquals(expected, emailModule.provideSuccessHtml());
+//  }
+//
+//  @Test
+//  void testProvideSuccessHtmlCustom() throws Exception {
+//    when(EMAIL_CONFIG.getMessageOptions())
+//        .thenReturn(new MessageOptions(null, null, null, null,
+//            new File(Resources.getResource("fixtures/success-page.html").toURI()).getAbsolutePath()));
+//
+//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+//
+//    String expected = Resources.toString(
+//        Resources.getResource("fixtures/success-page.html"), Charsets.UTF_8);
+//    assertEquals(expected, emailModule.provideSuccessHtml());
+//  }
+//
+//  @Test
+//  void testProvideVerificationHtmlDefault() throws IOException {
+//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+//
+//    String expected = Resources.toString(
+//        Resources.getResource("verification.html"), Charsets.UTF_8);
+//    assertEquals(expected, emailModule.provideBodyHtml());
+//  }
+//
+//  @Test
+//  void testProvideVerificationHtmlCustom() throws Exception {
+//    String path = new File(Resources.getResource(
+//        "fixtures/verification-email.html").toURI()).getAbsolutePath();
+//
+//    when(EMAIL_CONFIG.getMessageOptions())
+//        .thenReturn(new MessageOptions(null, path, null, null, null));
+//
+//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+//
+//    String expected = Resources.toString(
+//        Resources.getResource("fixtures/verification-email.html"), Charsets.UTF_8);
+//    assertEquals(expected, emailModule.provideBodyHtml());
+//  }
+//
+//  @Test
+//  void testProvideVerificationTextDefault() throws IOException {
+//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+//
+//    String expected = Resources.toString(
+//        Resources.getResource("verification.txt"), Charsets.UTF_8);
+//    assertEquals(expected, emailModule.provideBodyText());
+//  }
+//
+//  @Test
+//  void testProvideVerificationTextCustom() throws Exception {
+//    String path = new File(
+//        Resources.getResource("fixtures/verification-email.txt").toURI()).getAbsolutePath();
+//
+//    when(EMAIL_CONFIG.getMessageOptions())
+//        .thenReturn(new MessageOptions(null, null, path, null, null));
+//
+//    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
+//
+//    String expected = Resources.toString(
+//        Resources.getResource("fixtures/verification-email.txt"), Charsets.UTF_8);
+//    assertEquals(expected, emailModule.provideBodyText());
+//  }
+//}

--- a/application/src/test/java/com/sanction/thunder/email/MessageOptionsConfigurationTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/MessageOptionsConfigurationTest.java
@@ -1,0 +1,4 @@
+package com.sanction.thunder.email;
+
+class MessageOptionsConfigurationTest {
+}

--- a/application/src/test/java/com/sanction/thunder/email/MessageOptionsConfigurationTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/MessageOptionsConfigurationTest.java
@@ -1,4 +1,37 @@
 package com.sanction.thunder.email;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.google.common.io.Resources;
+
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.jackson.Jackson;
+import io.dropwizard.jersey.validation.Validators;
+
+import java.io.File;
+import javax.validation.Validator;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 class MessageOptionsConfigurationTest {
+  private final ObjectMapper mapper = Jackson.newObjectMapper();
+  private final Validator validator = Validators.newValidator();
+  private final YamlConfigurationFactory<MessageOptionsConfiguration> factory
+      = new YamlConfigurationFactory<>(MessageOptionsConfiguration.class, validator, mapper, "dw");
+
+  @Test
+  void testFromYaml() throws Exception {
+    MessageOptionsConfiguration configuration = factory.build(
+        new File(Resources.getResource("fixtures/message-options-config.yaml").toURI()));
+
+    assertAll("All configuration options are set",
+        () -> assertEquals("Test Subject", configuration.getSubject()),
+        () -> assertEquals("test-body.html", configuration.getBodyHtmlFilePath()),
+        () -> assertEquals("test-body.txt", configuration.getBodyTextFilePath()),
+        () -> assertEquals("TEST-PLACEHOLDER", configuration.getUrlPlaceholderString()),
+        () -> assertEquals("test-success-page.html", configuration.getSuccessHtmlFilePath()));
+  }
 }

--- a/application/src/test/java/com/sanction/thunder/email/MessageOptionsTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/MessageOptionsTest.java
@@ -1,4 +1,61 @@
 package com.sanction.thunder.email;
 
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 class MessageOptionsTest {
+
+  @Test
+  void testHashCodeSame() {
+    MessageOptions messageOptionsOne = new MessageOptions(
+        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+    MessageOptions messageOptionsTwo = new MessageOptions(
+        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+
+    assertEquals(messageOptionsOne.hashCode(), messageOptionsTwo.hashCode());
+  }
+
+  @Test
+  void testHashCodeDifferent() {
+    MessageOptions messageOptionsOne = new MessageOptions(
+        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+    MessageOptions messageOptionsTwo = new MessageOptions(
+        "new-subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+
+    assertNotEquals(messageOptionsOne.hashCode(), messageOptionsTwo.hashCode());
+  }
+
+  @Test
+  @SuppressWarnings({"SimplifiableJUnitAssertion", "EqualsWithItself"})
+  void testEqualsSameObject() {
+    MessageOptions messageOptions = new MessageOptions(
+        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+
+    assertTrue(() -> messageOptions.equals(messageOptions));
+  }
+
+  @Test
+  @SuppressWarnings("SimplifiableJUnitAssertion")
+  void testEqualsDifferentObject() {
+    MessageOptions messageOptions = new MessageOptions(
+        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+    Object objectTwo = new Object();
+
+    assertFalse(() -> messageOptions.equals(objectTwo));
+  }
+
+  @Test
+  void testToString() {
+    MessageOptions messageOptions = new MessageOptions(
+        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+    String expected = "MessageOptions "
+        + "[subject=subject, bodyHtml=bodyHtml, bodyText=bodyText, "
+        + "urlPlaceholderString=placeholder, successHtml=successHtml]";
+
+    assertEquals(expected, messageOptions.toString());
+  }
 }

--- a/application/src/test/java/com/sanction/thunder/email/MessageOptionsTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/MessageOptionsTest.java
@@ -1,0 +1,4 @@
+package com.sanction.thunder.email;
+
+class MessageOptionsTest {
+}

--- a/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
+++ b/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
@@ -1,264 +1,264 @@
-package com.sanction.thunder.resources;
-
-import com.codahale.metrics.MetricRegistry;
-
-import com.sanction.thunder.authentication.Key;
-import com.sanction.thunder.dao.DatabaseError;
-import com.sanction.thunder.dao.DatabaseException;
-import com.sanction.thunder.dao.UsersDao;
-import com.sanction.thunder.email.EmailService;
-import com.sanction.thunder.models.Email;
-import com.sanction.thunder.models.ResponseType;
-import com.sanction.thunder.models.User;
-
-import java.net.URI;
-import java.util.Collections;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
-
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-class VerificationResourceTest {
-  private static final String URL = "http://www.test.com/";
-  private static final String SUCCESS_HTML = "<html>success!</html>";
-  private static final String VERIFICATION_HTML = "<html>Verify</html>";
-  private static final String VERIFICATION_TEXT = "Verify";
-
-  private final EmailService emailService = mock(EmailService.class);
-  private final MetricRegistry metrics = new MetricRegistry();
-  private final UsersDao usersDao = mock(UsersDao.class);
-  private final Key key = mock(Key.class);
-
-  private static final UriInfo uriInfo = mock(UriInfo.class);
-  private static final UriBuilder uriBuilder = mock(UriBuilder.class);
-
-  private final User unverifiedMockUser =
-      new User(new Email("test@test.com", false, "verificationToken"),
-          "password", Collections.emptyMap());
-  private final User verifiedMockUser =
-      new User(new Email("test@test.com", true, "verificationToken"),
-          "password", Collections.emptyMap());
-  private final User nullDatabaseTokenMockUser =
-      new User(new Email("test@test.com", false, null),
-          "password", Collections.emptyMap());
-  private final User mismatchedTokenMockUser =
-      new User(new Email("test@test.com", false, "mismatchedToken"),
-          "password", Collections.emptyMap());
-
-  private final VerificationResource resource =
-      new VerificationResource(usersDao, metrics, emailService, SUCCESS_HTML, VERIFICATION_HTML,
-          VERIFICATION_TEXT);
-
-  @BeforeAll
-  static void setup() throws Exception {
-    when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
-    when(uriBuilder.queryParam(anyString(), any())).thenReturn(uriBuilder);
-    when(uriBuilder.build()).thenReturn(new URI(URL));
-
-    when(uriInfo.getBaseUriBuilder()).thenReturn(uriBuilder);
-  }
-
-  /* Verify User Tests */
-  @Test
-  void testCreateVerificationEmailWithNullEmail() {
-    Response response = resource.createVerificationEmail(uriInfo, key, null, "password");
-
-    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
-  }
-
-  @Test
-  void testCreateVerificationEmailWithNullPassword() {
-    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", null);
-
-    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
-  }
-
-  @Test
-  void testCreateVerificationEmailFindUserException() {
-    when(usersDao.findByEmail(anyString()))
-        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
-
-    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
-
-    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
-  }
-
-  @Test
-  void testCreateVerificationEmailUpdateUserException() {
-    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
-    when(usersDao.update(anyString(), any(User.class)))
-        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
-
-    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
-
-    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
-  }
-
-  @Test
-  void testCreateVerificationEmailSendEmailFailure() {
-    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
-    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
-    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
-        .thenReturn(false);
-
-    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
-
-    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
-  }
-
-  @Test
-  void testCreateVerificationEmailSuccess() {
-    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
-    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
-    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
-        .thenReturn(true);
-
-    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
-    User result = (User) response.getEntity();
-
-    assertAll("Assert successful send email",
-        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
-        () -> assertEquals(unverifiedMockUser, result));
-
-    // Verify that the correct HTML and Text were used to send the email
-    verify(emailService).sendEmail(
-        any(Email.class), eq("Account Verification"), eq(VERIFICATION_HTML), eq(VERIFICATION_TEXT));
-  }
-
-  @Test
-  void testCreateVerificationEmailCorrectUrl() {
-    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
-    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
-    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
-        .thenReturn(true);
-
-    String verificationHtml = "<html>Verify CODEGEN-URL</html>";
-    String verificationText = "Verify CODEGEN-URL";
-    VerificationResource resource = new VerificationResource(
-        usersDao, metrics, emailService, SUCCESS_HTML, verificationHtml, verificationText);
-
-    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
-    User result = (User) response.getEntity();
-
-    assertAll("Assert successful send email with inserted URL",
-        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
-        () -> assertEquals(unverifiedMockUser, result));
-
-    // Verify that the correct HTML and Text were used to send the email
-    String expectedVerificationHtml = "<html>Verify " + URL + "</html>";
-    String expectedVerificationText = "Verify " + URL;
-    verify(emailService).sendEmail(
-        any(Email.class), eq("Account Verification"),
-        eq(expectedVerificationHtml), eq(expectedVerificationText));
-  }
-
-  /* Verify Email Tests */
-  @Test
-  void testVerifyEmailWithNullEmail() {
-    Response response = resource.verifyEmail(null, "verificationToken", ResponseType.JSON);
-
-    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
-  }
-
-  @Test
-  void testVerifyEmailWithNullToken() {
-    Response response = resource.verifyEmail("test@test.com", null, ResponseType.JSON);
-
-    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
-  }
-
-  @Test
-  void testVerifyEmailFindUserException() {
-    when(usersDao.findByEmail(anyString()))
-        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
-
-    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-        ResponseType.JSON);
-
-    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
-  }
-
-  @Test
-  void testVerifyEmailWithNullDatabaseToken() {
-    when(usersDao.findByEmail(anyString())).thenReturn(nullDatabaseTokenMockUser);
-
-    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-        ResponseType.JSON);
-
-    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
-  }
-
-  @Test
-  void testVerifyEmailWithMismatchedToken() {
-    when(usersDao.findByEmail(anyString())).thenReturn(mismatchedTokenMockUser);
-
-    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-        ResponseType.JSON);
-
-    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
-  }
-
-  @Test
-  void testVerifyEmailUpdateUserException() {
-    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
-    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
-        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
-
-    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-        ResponseType.JSON);
-
-    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
-  }
-
-  @Test
-  void testVerifyEmailSuccess() {
-    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
-    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
-        .thenReturn(verifiedMockUser);
-
-    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-        ResponseType.JSON);
-    User result = (User) response.getEntity();
-
-    assertAll("Assert successful verify email with JSON response",
-        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
-        () -> assertEquals(verifiedMockUser, result));
-  }
-
-  @Test
-  void testVerifyEmailWithHtmlResponse() {
-    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
-    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
-        .thenReturn(verifiedMockUser);
-
-    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-        ResponseType.HTML);
-    URI result = response.getLocation();
-
-    assertAll("Assert successful verify email with HTML response",
-        () -> assertEquals(response.getStatusInfo(), Response.Status.SEE_OTHER),
-        () -> assertEquals(UriBuilder.fromUri("/verify/success").build(), result));
-  }
-
-  /* HTML Success Tests */
-  @Test
-  void testGetSuccessHtml() {
-    Response response = resource.getSuccessHtml();
-    String result = (String) response.getEntity();
-
-    assertAll("Assert successful HTML response",
-        () -> assertEquals(Response.Status.OK, response.getStatusInfo()),
-        () -> assertEquals(SUCCESS_HTML, result));
-  }
-}
+//package com.sanction.thunder.resources;
+//
+//import com.codahale.metrics.MetricRegistry;
+//
+//import com.sanction.thunder.authentication.Key;
+//import com.sanction.thunder.dao.DatabaseError;
+//import com.sanction.thunder.dao.DatabaseException;
+//import com.sanction.thunder.dao.UsersDao;
+//import com.sanction.thunder.email.EmailService;
+//import com.sanction.thunder.models.Email;
+//import com.sanction.thunder.models.ResponseType;
+//import com.sanction.thunder.models.User;
+//
+//import java.net.URI;
+//import java.util.Collections;
+//import javax.ws.rs.core.Response;
+//import javax.ws.rs.core.UriBuilder;
+//import javax.ws.rs.core.UriInfo;
+//
+//import org.junit.jupiter.api.BeforeAll;
+//import org.junit.jupiter.api.Test;
+//
+//import static org.junit.jupiter.api.Assertions.assertAll;
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//
+//class VerificationResourceTest {
+//  private static final String URL = "http://www.test.com/";
+//  private static final String SUCCESS_HTML = "<html>success!</html>";
+//  private static final String VERIFICATION_HTML = "<html>Verify</html>";
+//  private static final String VERIFICATION_TEXT = "Verify";
+//
+//  private final EmailService emailService = mock(EmailService.class);
+//  private final MetricRegistry metrics = new MetricRegistry();
+//  private final UsersDao usersDao = mock(UsersDao.class);
+//  private final Key key = mock(Key.class);
+//
+//  private static final UriInfo uriInfo = mock(UriInfo.class);
+//  private static final UriBuilder uriBuilder = mock(UriBuilder.class);
+//
+//  private final User unverifiedMockUser =
+//      new User(new Email("test@test.com", false, "verificationToken"),
+//          "password", Collections.emptyMap());
+//  private final User verifiedMockUser =
+//      new User(new Email("test@test.com", true, "verificationToken"),
+//          "password", Collections.emptyMap());
+//  private final User nullDatabaseTokenMockUser =
+//      new User(new Email("test@test.com", false, null),
+//          "password", Collections.emptyMap());
+//  private final User mismatchedTokenMockUser =
+//      new User(new Email("test@test.com", false, "mismatchedToken"),
+//          "password", Collections.emptyMap());
+//
+//  private final VerificationResource resource =
+//      new VerificationResource(usersDao, metrics, emailService, SUCCESS_HTML, VERIFICATION_HTML,
+//          VERIFICATION_TEXT);
+//
+//  @BeforeAll
+//  static void setup() throws Exception {
+//    when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
+//    when(uriBuilder.queryParam(anyString(), any())).thenReturn(uriBuilder);
+//    when(uriBuilder.build()).thenReturn(new URI(URL));
+//
+//    when(uriInfo.getBaseUriBuilder()).thenReturn(uriBuilder);
+//  }
+//
+//  /* Verify User Tests */
+//  @Test
+//  void testCreateVerificationEmailWithNullEmail() {
+//    Response response = resource.createVerificationEmail(uriInfo, key, null, "password");
+//
+//    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
+//  }
+//
+//  @Test
+//  void testCreateVerificationEmailWithNullPassword() {
+//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", null);
+//
+//    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
+//  }
+//
+//  @Test
+//  void testCreateVerificationEmailFindUserException() {
+//    when(usersDao.findByEmail(anyString()))
+//        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
+//
+//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
+//
+//    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
+//  }
+//
+//  @Test
+//  void testCreateVerificationEmailUpdateUserException() {
+//    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
+//    when(usersDao.update(anyString(), any(User.class)))
+//        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
+//
+//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
+//
+//    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
+//  }
+//
+//  @Test
+//  void testCreateVerificationEmailSendEmailFailure() {
+//    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
+//    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
+//    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
+//        .thenReturn(false);
+//
+//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
+//
+//    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
+//  }
+//
+//  @Test
+//  void testCreateVerificationEmailSuccess() {
+//    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
+//    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
+//    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
+//        .thenReturn(true);
+//
+//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
+//    User result = (User) response.getEntity();
+//
+//    assertAll("Assert successful send email",
+//        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
+//        () -> assertEquals(unverifiedMockUser, result));
+//
+//    // Verify that the correct HTML and Text were used to send the email
+//    verify(emailService).sendEmail(
+//        any(Email.class), eq("Account Verification"), eq(VERIFICATION_HTML), eq(VERIFICATION_TEXT));
+//  }
+//
+//  @Test
+//  void testCreateVerificationEmailCorrectUrl() {
+//    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
+//    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
+//    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
+//        .thenReturn(true);
+//
+//    String verificationHtml = "<html>Verify CODEGEN-URL</html>";
+//    String verificationText = "Verify CODEGEN-URL";
+//    VerificationResource resource = new VerificationResource(
+//        usersDao, metrics, emailService, SUCCESS_HTML, verificationHtml, verificationText);
+//
+//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
+//    User result = (User) response.getEntity();
+//
+//    assertAll("Assert successful send email with inserted URL",
+//        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
+//        () -> assertEquals(unverifiedMockUser, result));
+//
+//    // Verify that the correct HTML and Text were used to send the email
+//    String expectedVerificationHtml = "<html>Verify " + URL + "</html>";
+//    String expectedVerificationText = "Verify " + URL;
+//    verify(emailService).sendEmail(
+//        any(Email.class), eq("Account Verification"),
+//        eq(expectedVerificationHtml), eq(expectedVerificationText));
+//  }
+//
+//  /* Verify Email Tests */
+//  @Test
+//  void testVerifyEmailWithNullEmail() {
+//    Response response = resource.verifyEmail(null, "verificationToken", ResponseType.JSON);
+//
+//    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
+//  }
+//
+//  @Test
+//  void testVerifyEmailWithNullToken() {
+//    Response response = resource.verifyEmail("test@test.com", null, ResponseType.JSON);
+//
+//    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
+//  }
+//
+//  @Test
+//  void testVerifyEmailFindUserException() {
+//    when(usersDao.findByEmail(anyString()))
+//        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
+//
+//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+//        ResponseType.JSON);
+//
+//    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
+//  }
+//
+//  @Test
+//  void testVerifyEmailWithNullDatabaseToken() {
+//    when(usersDao.findByEmail(anyString())).thenReturn(nullDatabaseTokenMockUser);
+//
+//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+//        ResponseType.JSON);
+//
+//    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
+//  }
+//
+//  @Test
+//  void testVerifyEmailWithMismatchedToken() {
+//    when(usersDao.findByEmail(anyString())).thenReturn(mismatchedTokenMockUser);
+//
+//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+//        ResponseType.JSON);
+//
+//    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
+//  }
+//
+//  @Test
+//  void testVerifyEmailUpdateUserException() {
+//    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
+//    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
+//        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
+//
+//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+//        ResponseType.JSON);
+//
+//    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
+//  }
+//
+//  @Test
+//  void testVerifyEmailSuccess() {
+//    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
+//    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
+//        .thenReturn(verifiedMockUser);
+//
+//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+//        ResponseType.JSON);
+//    User result = (User) response.getEntity();
+//
+//    assertAll("Assert successful verify email with JSON response",
+//        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
+//        () -> assertEquals(verifiedMockUser, result));
+//  }
+//
+//  @Test
+//  void testVerifyEmailWithHtmlResponse() {
+//    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
+//    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
+//        .thenReturn(verifiedMockUser);
+//
+//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+//        ResponseType.HTML);
+//    URI result = response.getLocation();
+//
+//    assertAll("Assert successful verify email with HTML response",
+//        () -> assertEquals(response.getStatusInfo(), Response.Status.SEE_OTHER),
+//        () -> assertEquals(UriBuilder.fromUri("/verify/success").build(), result));
+//  }
+//
+//  /* HTML Success Tests */
+//  @Test
+//  void testGetSuccessHtml() {
+//    Response response = resource.getSuccessHtml();
+//    String result = (String) response.getEntity();
+//
+//    assertAll("Assert successful HTML response",
+//        () -> assertEquals(Response.Status.OK, response.getStatusInfo()),
+//        () -> assertEquals(SUCCESS_HTML, result));
+//  }
+//}

--- a/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
+++ b/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
@@ -1,264 +1,269 @@
-//package com.sanction.thunder.resources;
-//
-//import com.codahale.metrics.MetricRegistry;
-//
-//import com.sanction.thunder.authentication.Key;
-//import com.sanction.thunder.dao.DatabaseError;
-//import com.sanction.thunder.dao.DatabaseException;
-//import com.sanction.thunder.dao.UsersDao;
-//import com.sanction.thunder.email.EmailService;
-//import com.sanction.thunder.models.Email;
-//import com.sanction.thunder.models.ResponseType;
-//import com.sanction.thunder.models.User;
-//
-//import java.net.URI;
-//import java.util.Collections;
-//import javax.ws.rs.core.Response;
-//import javax.ws.rs.core.UriBuilder;
-//import javax.ws.rs.core.UriInfo;
-//
-//import org.junit.jupiter.api.BeforeAll;
-//import org.junit.jupiter.api.Test;
-//
-//import static org.junit.jupiter.api.Assertions.assertAll;
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//
-//class VerificationResourceTest {
-//  private static final String URL = "http://www.test.com/";
-//  private static final String SUCCESS_HTML = "<html>success!</html>";
-//  private static final String VERIFICATION_HTML = "<html>Verify</html>";
-//  private static final String VERIFICATION_TEXT = "Verify";
-//
-//  private final EmailService emailService = mock(EmailService.class);
-//  private final MetricRegistry metrics = new MetricRegistry();
-//  private final UsersDao usersDao = mock(UsersDao.class);
-//  private final Key key = mock(Key.class);
-//
-//  private static final UriInfo uriInfo = mock(UriInfo.class);
-//  private static final UriBuilder uriBuilder = mock(UriBuilder.class);
-//
-//  private final User unverifiedMockUser =
-//      new User(new Email("test@test.com", false, "verificationToken"),
-//          "password", Collections.emptyMap());
-//  private final User verifiedMockUser =
-//      new User(new Email("test@test.com", true, "verificationToken"),
-//          "password", Collections.emptyMap());
-//  private final User nullDatabaseTokenMockUser =
-//      new User(new Email("test@test.com", false, null),
-//          "password", Collections.emptyMap());
-//  private final User mismatchedTokenMockUser =
-//      new User(new Email("test@test.com", false, "mismatchedToken"),
-//          "password", Collections.emptyMap());
-//
-//  private final VerificationResource resource =
-//      new VerificationResource(usersDao, metrics, emailService, SUCCESS_HTML, VERIFICATION_HTML,
-//          VERIFICATION_TEXT);
-//
-//  @BeforeAll
-//  static void setup() throws Exception {
-//    when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
-//    when(uriBuilder.queryParam(anyString(), any())).thenReturn(uriBuilder);
-//    when(uriBuilder.build()).thenReturn(new URI(URL));
-//
-//    when(uriInfo.getBaseUriBuilder()).thenReturn(uriBuilder);
-//  }
-//
-//  /* Verify User Tests */
-//  @Test
-//  void testCreateVerificationEmailWithNullEmail() {
-//    Response response = resource.createVerificationEmail(uriInfo, key, null, "password");
-//
-//    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
-//  }
-//
-//  @Test
-//  void testCreateVerificationEmailWithNullPassword() {
-//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", null);
-//
-//    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
-//  }
-//
-//  @Test
-//  void testCreateVerificationEmailFindUserException() {
-//    when(usersDao.findByEmail(anyString()))
-//        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
-//
-//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
-//
-//    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
-//  }
-//
-//  @Test
-//  void testCreateVerificationEmailUpdateUserException() {
-//    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
-//    when(usersDao.update(anyString(), any(User.class)))
-//        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
-//
-//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
-//
-//    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
-//  }
-//
-//  @Test
-//  void testCreateVerificationEmailSendEmailFailure() {
-//    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
-//    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
-//    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
-//        .thenReturn(false);
-//
-//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
-//
-//    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
-//  }
-//
-//  @Test
-//  void testCreateVerificationEmailSuccess() {
-//    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
-//    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
-//    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
-//        .thenReturn(true);
-//
-//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
-//    User result = (User) response.getEntity();
-//
-//    assertAll("Assert successful send email",
-//        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
-//        () -> assertEquals(unverifiedMockUser, result));
-//
-//    // Verify that the correct HTML and Text were used to send the email
-//    verify(emailService).sendEmail(
-//        any(Email.class), eq("Account Verification"), eq(VERIFICATION_HTML), eq(VERIFICATION_TEXT));
-//  }
-//
-//  @Test
-//  void testCreateVerificationEmailCorrectUrl() {
-//    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
-//    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
-//    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
-//        .thenReturn(true);
-//
-//    String verificationHtml = "<html>Verify CODEGEN-URL</html>";
-//    String verificationText = "Verify CODEGEN-URL";
-//    VerificationResource resource = new VerificationResource(
-//        usersDao, metrics, emailService, SUCCESS_HTML, verificationHtml, verificationText);
-//
-//    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
-//    User result = (User) response.getEntity();
-//
-//    assertAll("Assert successful send email with inserted URL",
-//        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
-//        () -> assertEquals(unverifiedMockUser, result));
-//
-//    // Verify that the correct HTML and Text were used to send the email
-//    String expectedVerificationHtml = "<html>Verify " + URL + "</html>";
-//    String expectedVerificationText = "Verify " + URL;
-//    verify(emailService).sendEmail(
-//        any(Email.class), eq("Account Verification"),
-//        eq(expectedVerificationHtml), eq(expectedVerificationText));
-//  }
-//
-//  /* Verify Email Tests */
-//  @Test
-//  void testVerifyEmailWithNullEmail() {
-//    Response response = resource.verifyEmail(null, "verificationToken", ResponseType.JSON);
-//
-//    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
-//  }
-//
-//  @Test
-//  void testVerifyEmailWithNullToken() {
-//    Response response = resource.verifyEmail("test@test.com", null, ResponseType.JSON);
-//
-//    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
-//  }
-//
-//  @Test
-//  void testVerifyEmailFindUserException() {
-//    when(usersDao.findByEmail(anyString()))
-//        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
-//
-//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-//        ResponseType.JSON);
-//
-//    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
-//  }
-//
-//  @Test
-//  void testVerifyEmailWithNullDatabaseToken() {
-//    when(usersDao.findByEmail(anyString())).thenReturn(nullDatabaseTokenMockUser);
-//
-//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-//        ResponseType.JSON);
-//
-//    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
-//  }
-//
-//  @Test
-//  void testVerifyEmailWithMismatchedToken() {
-//    when(usersDao.findByEmail(anyString())).thenReturn(mismatchedTokenMockUser);
-//
-//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-//        ResponseType.JSON);
-//
-//    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
-//  }
-//
-//  @Test
-//  void testVerifyEmailUpdateUserException() {
-//    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
-//    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
-//        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
-//
-//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-//        ResponseType.JSON);
-//
-//    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
-//  }
-//
-//  @Test
-//  void testVerifyEmailSuccess() {
-//    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
-//    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
-//        .thenReturn(verifiedMockUser);
-//
-//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-//        ResponseType.JSON);
-//    User result = (User) response.getEntity();
-//
-//    assertAll("Assert successful verify email with JSON response",
-//        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
-//        () -> assertEquals(verifiedMockUser, result));
-//  }
-//
-//  @Test
-//  void testVerifyEmailWithHtmlResponse() {
-//    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
-//    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
-//        .thenReturn(verifiedMockUser);
-//
-//    Response response = resource.verifyEmail("test@test.com", "verificationToken",
-//        ResponseType.HTML);
-//    URI result = response.getLocation();
-//
-//    assertAll("Assert successful verify email with HTML response",
-//        () -> assertEquals(response.getStatusInfo(), Response.Status.SEE_OTHER),
-//        () -> assertEquals(UriBuilder.fromUri("/verify/success").build(), result));
-//  }
-//
-//  /* HTML Success Tests */
-//  @Test
-//  void testGetSuccessHtml() {
-//    Response response = resource.getSuccessHtml();
-//    String result = (String) response.getEntity();
-//
-//    assertAll("Assert successful HTML response",
-//        () -> assertEquals(Response.Status.OK, response.getStatusInfo()),
-//        () -> assertEquals(SUCCESS_HTML, result));
-//  }
-//}
+package com.sanction.thunder.resources;
+
+import com.codahale.metrics.MetricRegistry;
+
+import com.sanction.thunder.authentication.Key;
+import com.sanction.thunder.dao.DatabaseError;
+import com.sanction.thunder.dao.DatabaseException;
+import com.sanction.thunder.dao.UsersDao;
+import com.sanction.thunder.email.EmailService;
+import com.sanction.thunder.email.MessageOptions;
+import com.sanction.thunder.models.Email;
+import com.sanction.thunder.models.ResponseType;
+import com.sanction.thunder.models.User;
+
+import java.net.URI;
+import java.util.Collections;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class VerificationResourceTest {
+  private static final String URL = "http://www.test.com/";
+  private static final String SUCCESS_HTML = "<html>success!</html>";
+  private static final String VERIFICATION_HTML = "<html>Verify</html>";
+  private static final String VERIFICATION_TEXT = "Verify";
+
+  private final EmailService emailService = mock(EmailService.class);
+  private final MetricRegistry metrics = new MetricRegistry();
+  private final UsersDao usersDao = mock(UsersDao.class);
+  private final Key key = mock(Key.class);
+
+  private static final UriInfo uriInfo = mock(UriInfo.class);
+  private static final UriBuilder uriBuilder = mock(UriBuilder.class);
+
+  private final User unverifiedMockUser =
+      new User(new Email("test@test.com", false, "verificationToken"),
+          "password", Collections.emptyMap());
+  private final User verifiedMockUser =
+      new User(new Email("test@test.com", true, "verificationToken"),
+          "password", Collections.emptyMap());
+  private final User nullDatabaseTokenMockUser =
+      new User(new Email("test@test.com", false, null),
+          "password", Collections.emptyMap());
+  private final User mismatchedTokenMockUser =
+      new User(new Email("test@test.com", false, "mismatchedToken"),
+          "password", Collections.emptyMap());
+
+  private final MessageOptions messageOptions =
+      new MessageOptions("Subject", VERIFICATION_HTML, VERIFICATION_TEXT, "Placeholder", SUCCESS_HTML);
+
+  private final VerificationResource resource =
+      new VerificationResource(usersDao, metrics, emailService, messageOptions);
+
+  @BeforeAll
+  static void setup() throws Exception {
+    when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
+    when(uriBuilder.queryParam(anyString(), any())).thenReturn(uriBuilder);
+    when(uriBuilder.build()).thenReturn(new URI(URL));
+
+    when(uriInfo.getBaseUriBuilder()).thenReturn(uriBuilder);
+  }
+
+  /* Verify User Tests */
+  @Test
+  void testCreateVerificationEmailWithNullEmail() {
+    Response response = resource.createVerificationEmail(uriInfo, key, null, "password");
+
+    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
+  }
+
+  @Test
+  void testCreateVerificationEmailWithNullPassword() {
+    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", null);
+
+    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
+  }
+
+  @Test
+  void testCreateVerificationEmailFindUserException() {
+    when(usersDao.findByEmail(anyString()))
+        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
+
+    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
+
+    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void testCreateVerificationEmailUpdateUserException() {
+    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
+    when(usersDao.update(anyString(), any(User.class)))
+        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
+
+    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
+
+    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void testCreateVerificationEmailSendEmailFailure() {
+    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
+    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
+    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
+        .thenReturn(false);
+
+    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
+
+    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void testCreateVerificationEmailSuccess() {
+    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
+    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
+    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
+        .thenReturn(true);
+
+    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
+    User result = (User) response.getEntity();
+
+    assertAll("Assert successful send email",
+        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
+        () -> assertEquals(unverifiedMockUser, result));
+
+    // Verify that the correct HTML and Text were used to send the email
+    verify(emailService).sendEmail(
+        any(Email.class), eq("Subject"), eq(VERIFICATION_HTML), eq(VERIFICATION_TEXT));
+  }
+
+  @Test
+  void testCreateVerificationEmailCorrectUrl() {
+    when(usersDao.findByEmail(anyString())).thenReturn(unverifiedMockUser);
+    when(usersDao.update(anyString(), any(User.class))).thenReturn(unverifiedMockUser);
+    when(emailService.sendEmail(any(Email.class), anyString(), anyString(), anyString()))
+        .thenReturn(true);
+
+    String verificationHtml = "<html>Verify PLACEHOLDER</html>";
+    String verificationText = "Verify PLACEHOLDER";
+    MessageOptions messageOptions =
+        new MessageOptions("Subject", verificationHtml, verificationText, "PLACEHOLDER", SUCCESS_HTML);
+    VerificationResource resource = new VerificationResource(
+        usersDao, metrics, emailService, messageOptions);
+
+    Response response = resource.createVerificationEmail(uriInfo, key, "test@test.com", "password");
+    User result = (User) response.getEntity();
+
+    assertAll("Assert successful send email with inserted URL",
+        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
+        () -> assertEquals(unverifiedMockUser, result));
+
+    // Verify that the correct HTML and Text were used to send the email
+    String expectedVerificationHtml = "<html>Verify " + URL + "</html>";
+    String expectedVerificationText = "Verify " + URL;
+    verify(emailService).sendEmail(
+        any(Email.class), eq("Subject"),
+        eq(expectedVerificationHtml), eq(expectedVerificationText));
+  }
+
+  /* Verify Email Tests */
+  @Test
+  void testVerifyEmailWithNullEmail() {
+    Response response = resource.verifyEmail(null, "verificationToken", ResponseType.JSON);
+
+    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
+  }
+
+  @Test
+  void testVerifyEmailWithNullToken() {
+    Response response = resource.verifyEmail("test@test.com", null, ResponseType.JSON);
+
+    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
+  }
+
+  @Test
+  void testVerifyEmailFindUserException() {
+    when(usersDao.findByEmail(anyString()))
+        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
+
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.JSON);
+
+    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void testVerifyEmailWithNullDatabaseToken() {
+    when(usersDao.findByEmail(anyString())).thenReturn(nullDatabaseTokenMockUser);
+
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.JSON);
+
+    assertEquals(response.getStatusInfo(), Response.Status.INTERNAL_SERVER_ERROR);
+  }
+
+  @Test
+  void testVerifyEmailWithMismatchedToken() {
+    when(usersDao.findByEmail(anyString())).thenReturn(mismatchedTokenMockUser);
+
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.JSON);
+
+    assertEquals(response.getStatusInfo(), Response.Status.BAD_REQUEST);
+  }
+
+  @Test
+  void testVerifyEmailUpdateUserException() {
+    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
+    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
+        .thenThrow(new DatabaseException(DatabaseError.DATABASE_DOWN));
+
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.JSON);
+
+    assertEquals(response.getStatusInfo(), Response.Status.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  void testVerifyEmailSuccess() {
+    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
+    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
+        .thenReturn(verifiedMockUser);
+
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.JSON);
+    User result = (User) response.getEntity();
+
+    assertAll("Assert successful verify email with JSON response",
+        () -> assertEquals(response.getStatusInfo(), Response.Status.OK),
+        () -> assertEquals(verifiedMockUser, result));
+  }
+
+  @Test
+  void testVerifyEmailWithHtmlResponse() {
+    when(usersDao.findByEmail("test@test.com")).thenReturn(unverifiedMockUser);
+    when(usersDao.update(unverifiedMockUser.getEmail().getAddress(), verifiedMockUser))
+        .thenReturn(verifiedMockUser);
+
+    Response response = resource.verifyEmail("test@test.com", "verificationToken",
+        ResponseType.HTML);
+    URI result = response.getLocation();
+
+    assertAll("Assert successful verify email with HTML response",
+        () -> assertEquals(response.getStatusInfo(), Response.Status.SEE_OTHER),
+        () -> assertEquals(UriBuilder.fromUri("/verify/success").build(), result));
+  }
+
+  /* HTML Success Tests */
+  @Test
+  void testGetSuccessHtml() {
+    Response response = resource.getSuccessHtml();
+    String result = (String) response.getEntity();
+
+    assertAll("Assert successful HTML response",
+        () -> assertEquals(Response.Status.OK, response.getStatusInfo()),
+        () -> assertEquals(SUCCESS_HTML, result));
+  }
+}

--- a/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
+++ b/application/src/test/java/com/sanction/thunder/resources/VerificationResourceTest.java
@@ -57,8 +57,8 @@ class VerificationResourceTest {
       new User(new Email("test@test.com", false, "mismatchedToken"),
           "password", Collections.emptyMap());
 
-  private final MessageOptions messageOptions =
-      new MessageOptions("Subject", VERIFICATION_HTML, VERIFICATION_TEXT, "Placeholder", SUCCESS_HTML);
+  private final MessageOptions messageOptions = new MessageOptions(
+      "Subject", VERIFICATION_HTML, VERIFICATION_TEXT, "Placeholder", SUCCESS_HTML);
 
   private final VerificationResource resource =
       new VerificationResource(usersDao, metrics, emailService, messageOptions);
@@ -148,8 +148,8 @@ class VerificationResourceTest {
 
     String verificationHtml = "<html>Verify PLACEHOLDER</html>";
     String verificationText = "Verify PLACEHOLDER";
-    MessageOptions messageOptions =
-        new MessageOptions("Subject", verificationHtml, verificationText, "PLACEHOLDER", SUCCESS_HTML);
+    MessageOptions messageOptions = new MessageOptions(
+        "Subject", verificationHtml, verificationText, "PLACEHOLDER", SUCCESS_HTML);
     VerificationResource resource = new VerificationResource(
         usersDao, metrics, emailService, messageOptions);
 

--- a/application/src/test/java/com/sanction/thunder/util/EmailUtilitiesTest.java
+++ b/application/src/test/java/com/sanction/thunder/util/EmailUtilitiesTest.java
@@ -24,4 +24,14 @@ class EmailUtilitiesTest {
 
     assertEquals(expected, EmailUtilities.replaceUrlPlaceholder(contents, URL_PLACEHOLDER, url));
   }
+
+  @Test
+  void testReplaceWithCustomPlaceholder() {
+    String contents = "test contents PLACEHOLDER";
+    String url = "http://www.test.com";
+
+    String expected = "test contents " + url;
+
+    assertEquals(expected, EmailUtilities.replaceUrlPlaceholder(contents, "PLACEHOLDER", url));
+  }
 }

--- a/application/src/test/java/com/sanction/thunder/util/EmailUtilitiesTest.java
+++ b/application/src/test/java/com/sanction/thunder/util/EmailUtilitiesTest.java
@@ -12,7 +12,7 @@ class EmailUtilitiesTest {
     String contents = "test contents";
     String url = "http://www.test.com";
 
-    assertEquals(contents, EmailUtilities.replaceUrlPlaceholder(contents, url));
+    assertEquals(contents, EmailUtilities.replaceUrlPlaceholder(contents, URL_PLACEHOLDER, url));
   }
 
   @Test
@@ -22,6 +22,6 @@ class EmailUtilitiesTest {
 
     String expected = "test contents " + url;
 
-    assertEquals(expected, EmailUtilities.replaceUrlPlaceholder(contents, url));
+    assertEquals(expected, EmailUtilities.replaceUrlPlaceholder(contents, URL_PLACEHOLDER, url));
   }
 }

--- a/application/src/test/resources/fixtures/config.yaml
+++ b/application/src/test/resources/fixtures/config.yaml
@@ -9,10 +9,10 @@ ses:
   fromAddress: test@sanctionco.com
   messageOptions:
     subject: Test Subject
-    bodyHtmlFile: test-body.html
-    bodyTextFile: test-body.txt
+    bodyHtmlFilePath: test-body.html
+    bodyTextFilePath: test-body.txt
     urlPlaceholderString: TEST-PLACEHOLDER
-    successHtmlFile: test-success-page.html
+    successHtmlFilePath: test-success-page.html
 
 approvedKeys:
   - application: test-app

--- a/application/src/test/resources/fixtures/config.yaml
+++ b/application/src/test/resources/fixtures/config.yaml
@@ -7,9 +7,12 @@ ses:
   endpoint: test.email.com
   region: test-region-2
   fromAddress: test@sanctionco.com
-  successHtml: test-success-page.html
-  verificationHtml: test-verification-email.html
-  verificationText: test-verification-email.txt
+  messageOptions:
+    subject: Test Subject
+    bodyHtmlFile: test-body.html
+    bodyTextFile: test-body.txt
+    urlPlaceholderString: TEST-PLACEHOLDER
+    successHtmlFile: test-success-page.html
 
 approvedKeys:
   - application: test-app

--- a/application/src/test/resources/fixtures/message-options-config.yaml
+++ b/application/src/test/resources/fixtures/message-options-config.yaml
@@ -1,0 +1,5 @@
+subject: Test Subject
+bodyHtmlFilePath: test-body.html
+bodyTextFilePath: test-body.txt
+urlPlaceholderString: TEST-PLACEHOLDER
+successHtmlFilePath: test-success-page.html

--- a/config/cloud-dev-config.yaml
+++ b/config/cloud-dev-config.yaml
@@ -9,7 +9,6 @@ ses:
   endpoint: email.us-east-1.amazonaws.com
   region: us-east-1
   fromAddress: noreply@sanctionco.com
-  messageOptions:
 
 # Approved Application Authentication Credentials
 approvedKeys:

--- a/config/cloud-dev-config.yaml
+++ b/config/cloud-dev-config.yaml
@@ -9,9 +9,7 @@ ses:
   endpoint: email.us-east-1.amazonaws.com
   region: us-east-1
   fromAddress: noreply@sanctionco.com
-  successHtml:
-  verificationHtml:
-  verificationText:
+  messageOptions:
 
 # Approved Application Authentication Credentials
 approvedKeys:

--- a/config/local-dev-config.yaml
+++ b/config/local-dev-config.yaml
@@ -9,9 +9,9 @@ ses:
   endpoint: http://localhost:9001
   region: us-east-1
   fromAddress: noreply@sanctionco.com
-  successHtml:
-  verificationHtml:
-  verificationText:
+  messageOptions:
+    subject: Verification
+    urlPlaceholderString: PLACEHOLDER
 
 # Approved Application Authentication Credentials
 approvedKeys:

--- a/config/local-dev-config.yaml
+++ b/config/local-dev-config.yaml
@@ -10,8 +10,7 @@ ses:
   region: us-east-1
   fromAddress: noreply@sanctionco.com
   messageOptions:
-    subject: Verification
-    urlPlaceholderString: PLACEHOLDER
+    subject: Verification Message
 
 # Approved Application Authentication Credentials
 approvedKeys:

--- a/config/prod-config.yaml
+++ b/config/prod-config.yaml
@@ -9,7 +9,6 @@ ses:
   endpoint: email.us-east-1.amazonaws.com
   region: us-east-1
   fromAddress: noreply@sanctionco.com
-  messageOptions:
 
 # Approved Application Authentication Credentials
 approvedKeys:

--- a/config/prod-config.yaml
+++ b/config/prod-config.yaml
@@ -9,9 +9,7 @@ ses:
   endpoint: email.us-east-1.amazonaws.com
   region: us-east-1
   fromAddress: noreply@sanctionco.com
-  successHtml:
-  verificationHtml:
-  verificationText:
+  messageOptions:
 
 # Approved Application Authentication Credentials
 approvedKeys:

--- a/config/test-config.yaml
+++ b/config/test-config.yaml
@@ -9,9 +9,7 @@ ses:
   endpoint: http://localhost:9001
   region: us-east-1
   fromAddress: noreply@sanctionco.com
-  successHtml:
-  verificationHtml:
-  verificationText:
+  messageOptions:
 
 # Approved Application Authentication Credentials
 approvedKeys:

--- a/config/test-config.yaml
+++ b/config/test-config.yaml
@@ -9,7 +9,6 @@ ses:
   endpoint: http://localhost:9001
   region: us-east-1
   fromAddress: noreply@sanctionco.com
-  messageOptions:
 
 # Approved Application Authentication Credentials
 approvedKeys:


### PR DESCRIPTION
### This PR addresses:

<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists -->
#162.

- More email configuration options (Subject and placeholder string)
  - Users can customize the subject of the email message. Defaults to `Account Verification`
  - Users can customize the placeholder string in their text files. Defaults to `CODEGEN-URL`
- All email optional configuration is now contained in the `MessageOptionsConfiguration` class
- `VerificationResource` uses a `MessageOptions` object to hold all message options
- Updated tests accordingly

### I have verified that:

<!-- Ensure all of these boxes are checked -->
- [x] All related unit tests have been updated/created
- [x] Integration tests are passing

### Additional Notes
Still to do:

- [ ] Update Wiki documentation on configuration options
<!-- Put any other additional notes here for reviewers -->