### PR TITLE
Handle URL Placeholder Edge Cases

### DIFF
--- a/application/src/main/java/com/sanction/thunder/email/EmailModule.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailModule.java
@@ -91,6 +91,9 @@ public class EmailModule {
         && messageOptionsConfiguration.getBodyTextFilePath() != null
         ? messageOptionsConfiguration.getUrlPlaceholderString() : DEFAULT_PLACEHOLDER;
 
+    LOG.info("Using the URL Placeholder {} for the body HTML", bodyHtmlUrlPlaceholder);
+    LOG.info("Using the URL Placeholder {} for the body text", bodyTextUrlPlaceholder);
+
     return new MessageOptions(
         Optional.ofNullable(messageOptionsConfiguration.getSubject()).orElse(DEFAULT_SUBJECT),
         bodyHtml, bodyText, bodyHtmlUrlPlaceholder, bodyTextUrlPlaceholder, successHtml);

--- a/application/src/main/java/com/sanction/thunder/email/EmailModule.java
+++ b/application/src/main/java/com/sanction/thunder/email/EmailModule.java
@@ -75,16 +75,25 @@ public class EmailModule {
   @Provides
   MessageOptions provideMessageOptions(@Named("bodyHtml") String bodyHtml,
                                        @Named("bodyText") String bodyText,
-                                       @Named("urlPlaceholder") String urlPlaceholder,
                                        @Named("successHtml") String successHtml) {
     if (messageOptionsConfiguration == null) {
       return new MessageOptions(
-          DEFAULT_SUBJECT, bodyHtml, bodyText, urlPlaceholder, successHtml);
+          DEFAULT_SUBJECT, bodyHtml, bodyText,
+          DEFAULT_PLACEHOLDER, DEFAULT_PLACEHOLDER, successHtml);
     }
+
+    // Use the placeholder string for the body files only if both are customized
+    String bodyHtmlUrlPlaceholder = messageOptionsConfiguration.getUrlPlaceholderString() != null
+        && messageOptionsConfiguration.getBodyHtmlFilePath() != null
+        ? messageOptionsConfiguration.getUrlPlaceholderString() : DEFAULT_PLACEHOLDER;
+
+    String bodyTextUrlPlaceholder = messageOptionsConfiguration.getUrlPlaceholderString() != null
+        && messageOptionsConfiguration.getBodyTextFilePath() != null
+        ? messageOptionsConfiguration.getUrlPlaceholderString() : DEFAULT_PLACEHOLDER;
 
     return new MessageOptions(
         Optional.ofNullable(messageOptionsConfiguration.getSubject()).orElse(DEFAULT_SUBJECT),
-        bodyHtml, bodyText, urlPlaceholder, successHtml);
+        bodyHtml, bodyText, bodyHtmlUrlPlaceholder, bodyTextUrlPlaceholder, successHtml);
   }
 
   @Singleton
@@ -121,27 +130,6 @@ public class EmailModule {
     }
 
     return readFileAsResources(DEFAULT_BODY_TEXT_FILE);
-  }
-
-  @Singleton
-  @Provides
-  @Named("urlPlaceholder")
-  String provideUrlPlaceholder() {
-    if (messageOptionsConfiguration == null
-        || messageOptionsConfiguration.getUrlPlaceholderString() == null) {
-      return DEFAULT_PLACEHOLDER;
-    }
-
-    if (messageOptionsConfiguration.getUrlPlaceholderString() != null
-        && messageOptionsConfiguration.getBodyHtmlFilePath() == null
-        && messageOptionsConfiguration.getBodyTextFilePath() == null) {
-      LOG.warn("Custom URL placeholder was defined, but no custom body was defined.");
-      LOG.warn("Using the default URL placeholder: {}", DEFAULT_PLACEHOLDER);
-
-      return DEFAULT_PLACEHOLDER;
-    }
-
-    return messageOptionsConfiguration.getUrlPlaceholderString();
   }
 
   /**

--- a/application/src/main/java/com/sanction/thunder/email/MessageOptions.java
+++ b/application/src/main/java/com/sanction/thunder/email/MessageOptions.java
@@ -12,7 +12,8 @@ public class MessageOptions {
   private final String subject;
   private final String bodyHtml;
   private final String bodyText;
-  private final String urlPlaceholderString;
+  private final String bodyHtmlUrlPlaceholder;
+  private final String bodyTextUrlPlaceholder;
   private final String successHtml;
 
   /**
@@ -21,19 +22,23 @@ public class MessageOptions {
    * @param subject The subject of the email message.
    * @param bodyHtml The body of the email message in HTML form.
    * @param bodyText The body of the email message in plaintext form.
-   * @param urlPlaceholderString The placeholder string found in the body that should be replaced
-   *                             by a custom URL on each message request.
+   * @param bodyHtmlUrlPlaceholder The placeholder string found in the body HTML
+   *                               that should be replaced by a custom URL on each message request.
+   * @param bodyTextUrlPlaceholder The placeholder string found in the body text
+   *                               that should be replaced by a custom URL on each message request.
    * @param successHtml The HTML contents to display on successful verification.
    */
   public MessageOptions(@JsonProperty("subject") String subject,
                         @JsonProperty("bodyHtmlFile") String bodyHtml,
                         @JsonProperty("bodyTextFile") String bodyText,
-                        @JsonProperty("urlPlaceholderString") String urlPlaceholderString,
+                        @JsonProperty("bodyHtmlUrlPlaceholder") String bodyHtmlUrlPlaceholder,
+                        @JsonProperty("bodyTextUrlPlaceholder") String bodyTextUrlPlaceholder,
                         @JsonProperty("successHtmlFile") String successHtml) {
     this.subject = subject;
     this.bodyHtml = bodyHtml;
     this.bodyText = bodyText;
-    this.urlPlaceholderString = urlPlaceholderString;
+    this.bodyHtmlUrlPlaceholder = bodyHtmlUrlPlaceholder;
+    this.bodyTextUrlPlaceholder = bodyTextUrlPlaceholder;
     this.successHtml = successHtml;
   }
 
@@ -49,8 +54,12 @@ public class MessageOptions {
     return bodyText;
   }
 
-  public String getUrlPlaceholderString() {
-    return urlPlaceholderString;
+  public String getBodyHtmlUrlPlaceholder() {
+    return bodyHtmlUrlPlaceholder;
+  }
+
+  public String getBodyTextUrlPlaceholder() {
+    return bodyTextUrlPlaceholder;
   }
 
   public String getSuccessHtml() {
@@ -71,14 +80,15 @@ public class MessageOptions {
     return Objects.equals(this.subject, other.subject)
         && Objects.equals(this.bodyHtml, other.bodyHtml)
         && Objects.equals(this.bodyText, other.bodyText)
-        && Objects.equals(this.urlPlaceholderString, other.urlPlaceholderString)
+        && Objects.equals(this.bodyHtmlUrlPlaceholder, other.bodyHtmlUrlPlaceholder)
+        && Objects.equals(this.bodyTextUrlPlaceholder, other.bodyTextUrlPlaceholder)
         && Objects.equals(this.successHtml, other.successHtml);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        subject, bodyHtml, bodyText, urlPlaceholderString, successHtml);
+        subject, bodyHtml, bodyText, bodyHtmlUrlPlaceholder, bodyTextUrlPlaceholder, successHtml);
   }
 
   @Override
@@ -87,7 +97,8 @@ public class MessageOptions {
         .add(String.format("subject=%s", subject))
         .add(String.format("bodyHtml=%s", bodyHtml))
         .add(String.format("bodyText=%s", bodyText))
-        .add(String.format("urlPlaceholderString=%s", urlPlaceholderString))
+        .add(String.format("bodyHtmlUrlPlaceholder=%s", bodyHtmlUrlPlaceholder))
+        .add(String.format("bodyTextUrlPlaceholder=%s", bodyTextUrlPlaceholder))
         .add(String.format("successHtml=%s", successHtml))
         .toString();
   }

--- a/application/src/main/java/com/sanction/thunder/email/MessageOptionsConfiguration.java
+++ b/application/src/main/java/com/sanction/thunder/email/MessageOptionsConfiguration.java
@@ -2,6 +2,9 @@ package com.sanction.thunder.email;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Provides optional customization options for email messages.
+ */
 class MessageOptionsConfiguration {
 
   /* Optional configuration options */

--- a/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
+++ b/application/src/main/java/com/sanction/thunder/resources/VerificationResource.java
@@ -144,9 +144,9 @@ public class VerificationResource {
     boolean emailResult = emailService.sendEmail(result.getEmail(),
         messageOptions.getSubject(),
         EmailUtilities.replaceUrlPlaceholder(messageOptions.getBodyHtml(),
-            messageOptions.getUrlPlaceholderString(), verificationUrl),
+            messageOptions.getBodyHtmlUrlPlaceholder(), verificationUrl),
         EmailUtilities.replaceUrlPlaceholder(messageOptions.getBodyText(),
-            messageOptions.getUrlPlaceholderString(), verificationUrl));
+            messageOptions.getBodyTextUrlPlaceholder(), verificationUrl));
 
     if (!emailResult) {
       LOG.error("Error sending email to address {}", result.getEmail().getAddress());

--- a/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/EmailModuleTest.java
@@ -55,10 +55,63 @@ class EmailModuleTest {
     when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(null);
 
     MessageOptions expected = new MessageOptions(
-        "Account Verification", "bodyHtml", "bodyText", "CODEGEN-URL", "successHtml");
+        "Account Verification", "bodyHtml", "bodyText",
+        "CODEGEN-URL", "CODEGEN-URL", "successHtml");
 
     MessageOptions result = new EmailModule(EMAIL_CONFIG)
-        .provideMessageOptions("bodyHtml", "bodyText", "CODEGEN-URL", "successHtml");
+        .provideMessageOptions("bodyHtml", "bodyText", "successHtml");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testProvideMessageOptionsCustomPlaceholderWithNoCustomBody() {
+    when(OPTIONS_CONFIG.getSubject()).thenReturn("Test Subject");
+    when(OPTIONS_CONFIG.getUrlPlaceholderString()).thenReturn("Test Placeholder");
+    when(OPTIONS_CONFIG.getBodyHtmlFilePath()).thenReturn(null);
+    when(OPTIONS_CONFIG.getBodyTextFilePath()).thenReturn(null);
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(OPTIONS_CONFIG);
+
+    MessageOptions expected = new MessageOptions(
+        "Test Subject", "bodyHtml", "bodyText",
+        "CODEGEN-URL", "CODEGEN-URL", "successHtml");
+
+    MessageOptions result = new EmailModule(EMAIL_CONFIG)
+        .provideMessageOptions("bodyHtml", "bodyText", "successHtml");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testProvideMessageOptionsBodyHtmlPlaceholderCustom() {
+    when(OPTIONS_CONFIG.getSubject()).thenReturn("Test Subject");
+    when(OPTIONS_CONFIG.getUrlPlaceholderString()).thenReturn("Test Placeholder");
+    when(OPTIONS_CONFIG.getBodyHtmlFilePath()).thenReturn(null);
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(OPTIONS_CONFIG);
+
+    MessageOptions expected = new MessageOptions(
+        "Test Subject", "bodyHtml", "bodyText",
+        "CODEGEN-URL", "Test Placeholder", "successHtml");
+
+    MessageOptions result = new EmailModule(EMAIL_CONFIG)
+        .provideMessageOptions("bodyHtml", "bodyText", "successHtml");
+
+    assertEquals(expected, result);
+  }
+
+  @Test
+  void testProvideMessageOptionsBodyTextPlaceholderCustom() {
+    when(OPTIONS_CONFIG.getSubject()).thenReturn("Test Subject");
+    when(OPTIONS_CONFIG.getUrlPlaceholderString()).thenReturn("Test Placeholder");
+    when(OPTIONS_CONFIG.getBodyTextFilePath()).thenReturn(null);
+    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(OPTIONS_CONFIG);
+
+    MessageOptions expected = new MessageOptions(
+        "Test Subject", "bodyHtml", "bodyText",
+        "Test Placeholder", "CODEGEN-URL", "successHtml");
+
+    MessageOptions result = new EmailModule(EMAIL_CONFIG)
+        .provideMessageOptions("bodyHtml", "bodyText", "successHtml");
 
     assertEquals(expected, result);
   }
@@ -66,13 +119,15 @@ class EmailModuleTest {
   @Test
   void testProvideMessageOptionsCustom() {
     when(OPTIONS_CONFIG.getSubject()).thenReturn("Test Subject");
+    when(OPTIONS_CONFIG.getUrlPlaceholderString()).thenReturn("Test Placeholder");
     when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(OPTIONS_CONFIG);
 
     MessageOptions expected = new MessageOptions(
-        "Test Subject", "bodyHtml", "bodyText", "Test Placeholder", "successHtml");
+        "Test Subject", "bodyHtml", "bodyText",
+        "Test Placeholder", "Test Placeholder", "successHtml");
 
     MessageOptions result = new EmailModule(EMAIL_CONFIG)
-        .provideMessageOptions("bodyHtml", "bodyText", "Test Placeholder", "successHtml");
+        .provideMessageOptions("bodyHtml", "bodyText", "successHtml");
 
     assertEquals(expected, result);
   }
@@ -183,46 +238,5 @@ class EmailModuleTest {
     String expected = Resources.toString(
         Resources.getResource(CUSTOM_BODY_TEXT_RESOURCE_FILE), Charsets.UTF_8);
     assertEquals(expected, emailModule.provideBodyText());
-  }
-
-  @Test
-  void testProvideUrlPlaceholderNullOptions() {
-    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(null);
-
-    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-
-    assertEquals("CODEGEN-URL", emailModule.provideUrlPlaceholder());
-  }
-
-  @Test
-  void testProvideUrlPlaceholderNullCustom() {
-    when(OPTIONS_CONFIG.getUrlPlaceholderString()).thenReturn(null);
-    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(OPTIONS_CONFIG);
-
-    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-
-    assertEquals("CODEGEN-URL", emailModule.provideUrlPlaceholder());
-  }
-
-  @Test
-  void testProvideUrlPlaceholderCustom() {
-    when(OPTIONS_CONFIG.getUrlPlaceholderString()).thenReturn("PLACEHOLDER");
-    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(OPTIONS_CONFIG);
-
-    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-
-    assertEquals("PLACEHOLDER", emailModule.provideUrlPlaceholder());
-  }
-
-  @Test
-  void testProvideUrlPlaceholderCustomWithNoCustomBody() {
-    when(OPTIONS_CONFIG.getUrlPlaceholderString()).thenReturn("PLACEHOLDER");
-    when(OPTIONS_CONFIG.getBodyTextFilePath()).thenReturn(null);
-    when(OPTIONS_CONFIG.getBodyHtmlFilePath()).thenReturn(null);
-    when(EMAIL_CONFIG.getMessageOptionsConfiguration()).thenReturn(OPTIONS_CONFIG);
-
-    EmailModule emailModule = new EmailModule(EMAIL_CONFIG);
-
-    assertEquals("CODEGEN-URL", emailModule.provideUrlPlaceholder());
   }
 }

--- a/application/src/test/java/com/sanction/thunder/email/MessageOptionsTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/MessageOptionsTest.java
@@ -12,9 +12,9 @@ class MessageOptionsTest {
   @Test
   void testHashCodeSame() {
     MessageOptions messageOptionsOne = new MessageOptions(
-        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+        "subject", "bodyHtml", "bodyText", "htmlPlaceholder", "textPlaceholder", "successHtml");
     MessageOptions messageOptionsTwo = new MessageOptions(
-        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+        "subject", "bodyHtml", "bodyText", "htmlPlaceholder", "textPlaceholder", "successHtml");
 
     assertEquals(messageOptionsOne.hashCode(), messageOptionsTwo.hashCode());
   }
@@ -22,9 +22,9 @@ class MessageOptionsTest {
   @Test
   void testHashCodeDifferent() {
     MessageOptions messageOptionsOne = new MessageOptions(
-        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+        "subject", "bodyHtml", "bodyText", "htmlPlaceholder", "textPlaceholder", "successHtml");
     MessageOptions messageOptionsTwo = new MessageOptions(
-        "new-subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+        "new-subject", "bodyHtml", "bodyText", "htmlPlaceholder", "textPlaceholder", "successHtml");
 
     assertNotEquals(messageOptionsOne.hashCode(), messageOptionsTwo.hashCode());
   }
@@ -33,7 +33,7 @@ class MessageOptionsTest {
   @SuppressWarnings({"SimplifiableJUnitAssertion", "EqualsWithItself"})
   void testEqualsSameObject() {
     MessageOptions messageOptions = new MessageOptions(
-        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+        "subject", "bodyHtml", "bodyText", "placeholder", "textPlaceholder", "successHtml");
 
     assertTrue(() -> messageOptions.equals(messageOptions));
   }
@@ -42,7 +42,7 @@ class MessageOptionsTest {
   @SuppressWarnings("SimplifiableJUnitAssertion")
   void testEqualsDifferentObject() {
     MessageOptions messageOptions = new MessageOptions(
-        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+        "subject", "bodyHtml", "bodyText", "placeholder", "textPlaceholder", "successHtml");
     Object objectTwo = new Object();
 
     assertFalse(() -> messageOptions.equals(objectTwo));
@@ -51,10 +51,11 @@ class MessageOptionsTest {
   @Test
   void testToString() {
     MessageOptions messageOptions = new MessageOptions(
-        "subject", "bodyHtml", "bodyText", "placeholder", "successHtml");
+        "subject", "bodyHtml", "bodyText", "htmlPlaceholder", "textPlaceholder", "successHtml");
     String expected = "MessageOptions "
         + "[subject=subject, bodyHtml=bodyHtml, bodyText=bodyText, "
-        + "urlPlaceholderString=placeholder, successHtml=successHtml]";
+        + "bodyHtmlUrlPlaceholder=htmlPlaceholder, bodyTextUrlPlaceholder=textPlaceholder, "
+        + "successHtml=successHtml]";
 
     assertEquals(expected, messageOptions.toString());
   }

--- a/application/src/test/java/com/sanction/thunder/email/MessageOptionsTest.java
+++ b/application/src/test/java/com/sanction/thunder/email/MessageOptionsTest.java
@@ -33,7 +33,7 @@ class MessageOptionsTest {
   @SuppressWarnings({"SimplifiableJUnitAssertion", "EqualsWithItself"})
   void testEqualsSameObject() {
     MessageOptions messageOptions = new MessageOptions(
-        "subject", "bodyHtml", "bodyText", "placeholder", "textPlaceholder", "successHtml");
+        "subject", "bodyHtml", "bodyText", "htmlPlaceholder", "textPlaceholder", "successHtml");
 
     assertTrue(() -> messageOptions.equals(messageOptions));
   }
@@ -42,7 +42,7 @@ class MessageOptionsTest {
   @SuppressWarnings("SimplifiableJUnitAssertion")
   void testEqualsDifferentObject() {
     MessageOptions messageOptions = new MessageOptions(
-        "subject", "bodyHtml", "bodyText", "placeholder", "textPlaceholder", "successHtml");
+        "subject", "bodyHtml", "bodyText", "htmlPlaceholder", "textPlaceholder", "successHtml");
     Object objectTwo = new Object();
 
     assertFalse(() -> messageOptions.equals(objectTwo));


### PR DESCRIPTION
### This PR addresses:

<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists -->
Fully resolves #162.

Handle edge cases where:

1. User specifies a custom placeholder but no custom body files: Use the default placeholder
2. User specifies a custom placeholder with only one custom body file: Use the custom placeholder for the custom file, use the default placeholder for the default file

### I have verified that:

<!-- Ensure all of these boxes are checked -->
- [x] All related unit tests have been updated/created
- [x] Integration tests are passing

### Additional Notes

<!-- Put any other additional notes here for reviewers -->