### PR TITLE
Fix bug with incorrect response message

### DIFF
--- a/application/src/main/java/com/sanctionco/thunder/resources/UserResource.java
+++ b/application/src/main/java/com/sanctionco/thunder/resources/UserResource.java
@@ -167,7 +167,7 @@ public class UserResource {
       result = usersDao.update(existingEmail, user);
     } catch (DatabaseException e) {
       LOG.error("Error updating user {} in database. Caused by: {}", email, e.getErrorKind());
-      return e.getErrorKind().buildResponse(email);
+      return e.getErrorKind().buildResponse(user.getEmail().getAddress());
     }
 
     LOG.info("Successfully updated user {}.", email);


### PR DESCRIPTION
### This PR addresses:
<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists. -->
Closes #238.

Before, if updating a user's email address and there was already a user with the new email address in the database, the CONFLICT error message would be incorrect. This fixes that.

For example:
1. Insert user `firstuser@gmail.com`
2. Insert user `seconduser@gmail.com`
3. Update the first user's email address to `seconduser@gmail.com`

BEFORE the bug fix, the response message would be:
```
User firstuser@simulator.amazonses.com already exists in the database.
```

This doesn't make sense because `firstuser@gmail.com` is the one that is getting their email changed. We want it to say that the new email already exists.

After the bug fix:
```
User seconduser@simulator.amazonses.com already exists in the database.
```

Better!

### Required documentation changes:
<!-- List the pages in the wiki that will need to be updated when this is merged. -->
None

### I have verified that:
<!-- Ensure all of these boxes are checked. -->
- [x] All related unit tests have been updated/created
- [x] I have listed the required documentation changes above

### Additional Notes
<!-- Put any other additional notes here for reviewers. -->