### PR TITLE
Add Nexus Staging Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@
   <a href="https://codecov.io/gh/RohanNagar/thunder">
     <img src="https://codecov.io/gh/RohanNagar/thunder/branch/master/graph/badge.svg" alt="Coverage Status">
   </a>
-  <a href="https://jitpack.io/#RohanNagar/thunder">
-    <img src="https://jitpack.io/v/RohanNagar/thunder.svg" alt="Release">
+  <a href="https://search.maven.org/artifact/com.sanctionco.thunder/client/2.0.0/jar">
+    <img src="https://img.shields.io/maven-central/v/com.sanctionco.thunder/client.svg?colorB=brightgreen&label=maven%20central" alt="Maven Central">
+  </a>
+  <a href="http://javadoc.io/doc/com.sanctionco.thunder/client">
+    <img src="http://javadoc.io/badge/com.sanctionco.thunder/client.svg" alt="Javadoc">
   </a>
   <a href="https://hub.docker.com/r/rohannagar/thunder">
     <img src="https://img.shields.io/docker/pulls/rohannagar/thunder.svg" alt="Docker Pulls">

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,18 @@
               </execution>
             </executions>
           </plugin>
+
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.7</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <gpg-plugin.version>1.6</gpg-plugin.version>
     <jacoco.version>0.8.1</jacoco.version>
     <javadoc-plugin.version>3.0.1</javadoc-plugin.version>
+    <nexus-plugin.version>1.6.7</nexus-plugin.version>
     <release-plugin.version>2.5.3</release-plugin.version>
     <source-plugin.version>3.0.1</source-plugin.version>
     <surefire.version>2.22.0</surefire.version>
@@ -142,10 +143,11 @@
             </executions>
           </plugin>
 
+          <!-- Deploy to Maven Central -->
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.6.7</version>
+            <version>${nexus-plugin.version}</version>
             <extensions>true</extensions>
             <configuration>
               <serverId>ossrh</serverId>


### PR DESCRIPTION
### This PR addresses:
<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists. -->
This plugin is necessary to release to the Nexus Staging Repo (Maven Central). This was missing, which is why performing the v2.0 release didn't deploy to central. I've gone ahead and deployed v2.0 to central manually. From now on, it should deploy when doing a release.

Closes #140 by adding Maven Central and Javadoc badges to the README

### Required documentation changes:
<!-- List the pages in the wiki that will need to be updated when this is merged. -->
None

### I have verified that:
<!-- Ensure all of these boxes are checked. -->
- [x] All related unit tests have been updated/created
- [x] I have listed the required documentation changes above

### Additional Notes
<!-- Put any other additional notes here for reviewers. -->
