### PR TITLE
Disallow Verification Status Changes on Update

### DIFF
--- a/application/src/main/java/com/sanctionco/thunder/crypto/MD5HashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/MD5HashService.java
@@ -1,19 +1,11 @@
 package com.sanctionco.thunder.crypto;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-
-import org.apache.commons.codec.binary.Hex;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.sanctionco.thunder.util.HashUtilities;
 
 /**
  * Provides hashing and verifying methods implemented with MD5.
  */
 public class MD5HashService implements HashService {
-  private static final Logger LOG = LoggerFactory.getLogger(MD5HashService.class);
 
   /**
    * Determines if the given string matches the given hashed string.
@@ -24,18 +16,7 @@ public class MD5HashService implements HashService {
    */
   @Override
   public boolean isMatch(String plaintext, String hashed) {
-    String computedHash;
-
-    try {
-      MessageDigest md = MessageDigest.getInstance("MD5");
-
-      byte[] digest = md.digest(plaintext.getBytes(StandardCharsets.UTF_8));
-      computedHash = Hex.encodeHexString(digest);
-    } catch (NoSuchAlgorithmException e) {
-      LOG.error("An expected error occurred while computing an MD5 hash. "
-          + "Requests are going to fail while this continues.", e);
-      return false;
-    }
+    String computedHash = HashUtilities.performHash("MD5", plaintext);
 
     return computedHash.equals(hashed);
   }

--- a/application/src/main/java/com/sanctionco/thunder/util/EmailUtilities.java
+++ b/application/src/main/java/com/sanctionco/thunder/util/EmailUtilities.java
@@ -4,7 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Provides utility classes related to email addresses and messages. Used
+ * Provides utility methods related to email addresses and messages. Used
  * in the {@link com.sanctionco.thunder.email.EmailService EmailService} class.
  */
 public class EmailUtilities {

--- a/application/src/main/java/com/sanctionco/thunder/util/HashUtilities.java
+++ b/application/src/main/java/com/sanctionco/thunder/util/HashUtilities.java
@@ -1,0 +1,38 @@
+package com.sanctionco.thunder.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import org.apache.commons.codec.binary.Hex;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides utility methods related to hashing String values.
+ */
+public class HashUtilities {
+  private static final Logger LOG = LoggerFactory.getLogger(HashUtilities.class);
+
+  /**
+   * Performs a hash of the given plaintext using the given hash algorithm.
+   *
+   * @param hashAlgorithm The hash algorithm to use when hashing.
+   * @param plaintext The plaintext to hash.
+   * @return The hashed value of the plaintext.
+   */
+  public static String performHash(String hashAlgorithm, String plaintext) {
+    try {
+      MessageDigest md = MessageDigest.getInstance(hashAlgorithm);
+
+      byte[] digest = md.digest(plaintext.getBytes(StandardCharsets.UTF_8));
+      return Hex.encodeHexString(digest);
+    } catch (NoSuchAlgorithmException e) {
+      LOG.error("Attempted to hash with algorithm {}, which is not supported by the Java library. "
+          + "Requests are going to fail while this continues.", hashAlgorithm, e);
+
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/application/src/test/java/com/sanctionco/thunder/util/HashUtilitiesTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/util/HashUtilitiesTest.java
@@ -9,6 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class HashUtilitiesTest {
 
   @Test
+  void testConstructInstance() {
+    new HashUtilities();
+  }
+
+  @Test
   void testMd5Hash() {
     String plaintext = "password";
     String hashed = "5f4dcc3b5aa765d61d8327deb882cf99";

--- a/application/src/test/java/com/sanctionco/thunder/util/HashUtilitiesTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/util/HashUtilitiesTest.java
@@ -1,0 +1,39 @@
+package com.sanctionco.thunder.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HashUtilitiesTest {
+
+  @Test
+  void testMd5Hash() {
+    String plaintext = "password";
+    String hashed = "5f4dcc3b5aa765d61d8327deb882cf99";
+
+    String computed = HashUtilities.performHash("MD5", plaintext);
+
+    assertEquals(hashed, computed);
+  }
+
+  @Test
+  void testMd5HashMismatch() {
+    String plaintext = "password";
+    String hashed = "5e9d11a14ad1c8dd77e98ef9b53fd1ba";
+
+    String computed = HashUtilities.performHash("MD5", plaintext);
+
+    assertNotEquals(hashed, computed);
+  }
+
+  @Test
+  void testUnsupportedAlgorithmThrows() {
+    Exception e = assertThrows(RuntimeException.class,
+        () -> HashUtilities.performHash("badHashType", "plaintext"));
+
+    assertEquals("java.security.NoSuchAlgorithmException: "
+        + "badHashType MessageDigest not available", e.getMessage());
+  }
+}

--- a/scripts/tests/disabled-email/tests.yaml
+++ b/scripts/tests/disabled-email/tests.yaml
@@ -303,8 +303,8 @@
   expectedResponse:
     email:
       address: success@simulator.amazonses.com
-      verified: true
-      verificationToken: GENERATED
+      verified: false
+      verificationToken: null
     password: 5f4dcc3b5aa765d61d8327deb882cf99
     properties:
       uniqueID: NEW_ID
@@ -332,8 +332,8 @@
   expectedResponse:
     email:
       address: newemail@gmail.com
-      verified: true
-      verificationToken: GENERATED
+      verified: false
+      verificationToken: null
     password: 5f4dcc3b5aa765d61d8327deb882cf99
     properties:
       uniqueID: NEW_ID
@@ -400,8 +400,8 @@
   expectedResponse:
     email:
       address: newemail@gmail.com
-      verified: true
-      verificationToken: GENERATED
+      verified: false
+      verificationToken: null
     password: 5f4dcc3b5aa765d61d8327deb882cf99
     properties:
       uniqueID: NEW_ID

--- a/scripts/tests/general/tests.yaml
+++ b/scripts/tests/general/tests.yaml
@@ -485,8 +485,8 @@
   expectedResponse:
     email:
       address: newemail@gmail.com
-      verified: true
-      verificationToken: GENERATED
+      verified: false
+      verificationToken: null
     password: 5f4dcc3b5aa765d61d8327deb882cf99
     properties:
       uniqueID: NEW_ID
@@ -553,8 +553,8 @@
   expectedResponse:
     email:
       address: newemail@gmail.com
-      verified: true
-      verificationToken: GENERATED
+      verified: false
+      verificationToken: null
     password: 5f4dcc3b5aa765d61d8327deb882cf99
     properties:
       uniqueID: NEW_ID


### PR DESCRIPTION
### This PR addresses:
<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists. -->
Fixes #268.

- When updating a user, don't allow the update to overwrite the verification status. Either keep the existing verification status, or if it is a new email, reset the verification status.
- This PR also moves the MD5 hash function into a static method in `HashUtilities` in order to allow for easier unit testing.

### I have verified that:
<!-- Ensure all of these boxes are checked. -->
- [x] All related unit tests have been updated/created
- [x] All related integration tests have been updated/created
- [x] I have updated relevant documentation in the `docs/` directory

### Additional Notes
<!-- Put any other additional notes here for reviewers. -->
There aren't any relevant docs for this right now but I will add some docs about this behavior later.

Also, I will open an issue to add an endpoint that allows for resetting a user's verification status.