### PR TITLE
Feature: Server Side Hashing

### DIFF
--- a/application/src/main/java/com/sanctionco/thunder/ThunderModule.java
+++ b/application/src/main/java/com/sanctionco/thunder/ThunderModule.java
@@ -73,8 +73,7 @@ class ThunderModule {
     LOG.info("Server-side hashing: {}",
         config.getHashConfiguration().serverSideHash());
 
-    return config.getHashConfiguration()
-        .getAlgorithm()
+    return config.getHashConfiguration().getAlgorithm()
         .newHashService(config.getHashConfiguration().serverSideHash());
   }
 }

--- a/application/src/main/java/com/sanctionco/thunder/ThunderModule.java
+++ b/application/src/main/java/com/sanctionco/thunder/ThunderModule.java
@@ -70,7 +70,11 @@ class ThunderModule {
   HashService provideHashService() {
     LOG.info("Using {} as the password hashing algorithm.",
         config.getHashConfiguration().getAlgorithm());
+    LOG.info("Server-side hashing: {}",
+        config.getHashConfiguration().serverSideHash());
 
-    return config.getHashConfiguration().getAlgorithm().newHashService();
+    return config.getHashConfiguration()
+        .getAlgorithm()
+        .newHashService(config.getHashConfiguration().serverSideHash());
   }
 }

--- a/application/src/main/java/com/sanctionco/thunder/crypto/BCryptHashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/BCryptHashService.java
@@ -3,8 +3,8 @@ package com.sanctionco.thunder.crypto;
 import org.mindrot.jbcrypt.BCrypt;
 
 /**
- * Provides the BCrypt implementation for the {@link HashService}. Provides a method that is used
- * to verify that hashed strings match.
+ * Provides the BCrypt implementation for the {@link HashService}. Provides methods to hash and to
+ * verify existing hashes match.
  *
  * @see HashService
  */
@@ -13,5 +13,10 @@ public class BCryptHashService implements HashService {
   @Override
   public boolean isMatch(String plaintext, String hashed) {
     return BCrypt.checkpw(plaintext, hashed);
+  }
+
+  @Override
+  public String hash(String plaintext) {
+    return BCrypt.hashpw(plaintext, BCrypt.gensalt());
   }
 }

--- a/application/src/main/java/com/sanctionco/thunder/crypto/BCryptHashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/BCryptHashService.java
@@ -8,7 +8,11 @@ import org.mindrot.jbcrypt.BCrypt;
  *
  * @see HashService
  */
-public class BCryptHashService implements HashService {
+public class BCryptHashService extends HashService {
+
+  BCryptHashService(boolean serverSideHashEnabled) {
+    super(serverSideHashEnabled);
+  }
 
   @Override
   public boolean isMatch(String plaintext, String hashed) {
@@ -17,6 +21,10 @@ public class BCryptHashService implements HashService {
 
   @Override
   public String hash(String plaintext) {
-    return BCrypt.hashpw(plaintext, BCrypt.gensalt());
+    if (serverSideHashEnabled()) {
+      return BCrypt.hashpw(plaintext, BCrypt.gensalt());
+    }
+
+    return plaintext;
   }
 }

--- a/application/src/main/java/com/sanctionco/thunder/crypto/HashAlgorithm.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/HashAlgorithm.java
@@ -6,20 +6,20 @@ package com.sanctionco.thunder.crypto;
 public enum HashAlgorithm {
   BCRYPT("bcrypt") {
     @Override
-    public HashService newHashService() {
-      return new BCryptHashService();
+    public HashService newHashService(boolean serverSideHashEnabled) {
+      return new BCryptHashService(serverSideHashEnabled);
     }
   },
   MD5("md5") {
     @Override
-    public HashService newHashService() {
-      return new MD5HashService();
+    public HashService newHashService(boolean serverSideHashEnabled) {
+      return new MD5HashService(serverSideHashEnabled);
     }
   },
   SIMPLE("simple") {
     @Override
-    public HashService newHashService() {
-      return new SimpleHashService();
+    public HashService newHashService(boolean serverSideHashEnabled) {
+      return new SimpleHashService(serverSideHashEnabled);
     }
   };
 
@@ -53,7 +53,9 @@ public enum HashAlgorithm {
   /**
    * Creates a new hash service that can be used to verify passwords.
    *
+   * @param serverSideHashEnabled {@code true} if server side hashing should be
+   *                              enabled; {@code false} otherwise
    * @return the new {@code HashService} object
    */
-  public abstract HashService newHashService();
+  public abstract HashService newHashService(boolean serverSideHashEnabled);
 }

--- a/application/src/main/java/com/sanctionco/thunder/crypto/HashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/HashService.java
@@ -4,7 +4,12 @@ package com.sanctionco.thunder.crypto;
  * Provides the base interface for the {@code HashService}. Provides methods to hash and to
  * verify existing hashes match.
  */
-public interface HashService {
+public abstract class HashService {
+  private final boolean serverSideHashEnabled;
+
+  public HashService(boolean serverSideHashEnabled) {
+    this.serverSideHashEnabled = serverSideHashEnabled;
+  }
 
   /**
    * Determines if the plaintext matches the given hashed string.
@@ -13,13 +18,23 @@ public interface HashService {
    * @param hashed the hashed string to check against
    * @return {@code true} if the plaintext is a match; {@code false} otherwise
    */
-  boolean isMatch(String plaintext, String hashed);
+  public abstract boolean isMatch(String plaintext, String hashed);
 
   /**
-   * Performs a hash of the plaintext.
+   * Performs a hash of the plaintext if server side hashing is enabled. If server side
+   * hashing is disabled, the plaintext will be returned without modification.
    *
    * @param plaintext the text to hash
-   * @return the computed hash
+   * @return the computed hash or the original plaintext if server side hashing is disabled
    */
-  String hash(String plaintext);
+  public abstract String hash(String plaintext);
+
+  /**
+   * Determines if server side password hashing is currently enabled.
+   *
+   * @return {@code true} if server side hashing is enabled; {@code false} otherwise
+   */
+  boolean serverSideHashEnabled() {
+    return serverSideHashEnabled;
+  }
 }

--- a/application/src/main/java/com/sanctionco/thunder/crypto/HashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/HashService.java
@@ -1,8 +1,8 @@
 package com.sanctionco.thunder.crypto;
 
 /**
- * Provides the base interface for the {@code HashService}. Provides a method that is used to
- * verify that hashed strings match.
+ * Provides the base interface for the {@code HashService}. Provides methods to hash and to
+ * verify existing hashes match.
  */
 public interface HashService {
 
@@ -14,4 +14,12 @@ public interface HashService {
    * @return {@code true} if the plaintext is a match; {@code false} otherwise
    */
   boolean isMatch(String plaintext, String hashed);
+
+  /**
+   * Performs a hash of the plaintext.
+   *
+   * @param plaintext the text to hash
+   * @return the computed hash
+   */
+  String hash(String plaintext);
 }

--- a/application/src/main/java/com/sanctionco/thunder/crypto/MD5HashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/MD5HashService.java
@@ -8,7 +8,11 @@ import com.sanctionco.thunder.util.HashUtilities;
  *
  * @see HashService
  */
-public class MD5HashService implements HashService {
+public class MD5HashService extends HashService {
+
+  MD5HashService(boolean serverSideHashEnabled) {
+    super(serverSideHashEnabled);
+  }
 
   @Override
   public boolean isMatch(String plaintext, String hashed) {
@@ -19,6 +23,10 @@ public class MD5HashService implements HashService {
 
   @Override
   public String hash(String plaintext) {
-    return HashUtilities.performHash("MD5", plaintext);
+    if (serverSideHashEnabled()) {
+      return HashUtilities.performHash("MD5", plaintext);
+    }
+
+    return plaintext;
   }
 }

--- a/application/src/main/java/com/sanctionco/thunder/crypto/MD5HashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/MD5HashService.java
@@ -3,8 +3,8 @@ package com.sanctionco.thunder.crypto;
 import com.sanctionco.thunder.util.HashUtilities;
 
 /**
- * Provides the MD5 implementation for the {@link HashService}. Provides a method that is used to
- * verify that hashed strings match.
+ * Provides the MD5 implementation for the {@link HashService}. Provides methods to hash and to
+ * verify existing hashes match.
  *
  * @see HashService
  */
@@ -15,5 +15,10 @@ public class MD5HashService implements HashService {
     String computedHash = HashUtilities.performHash("MD5", plaintext);
 
     return computedHash.equals(hashed);
+  }
+
+  @Override
+  public String hash(String plaintext) {
+    return HashUtilities.performHash("MD5", plaintext);
   }
 }

--- a/application/src/main/java/com/sanctionco/thunder/crypto/PasswordHashConfiguration.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/PasswordHashConfiguration.java
@@ -20,4 +20,12 @@ public class PasswordHashConfiguration {
   public HashAlgorithm getAlgorithm() {
     return algorithm;
   }
+
+  @Valid
+  @JsonProperty("serverSideHash")
+  private final Boolean serverSideHash = false;
+
+  public Boolean serverSideHash() {
+    return serverSideHash;
+  }
 }

--- a/application/src/main/java/com/sanctionco/thunder/crypto/SimpleHashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/SimpleHashService.java
@@ -1,7 +1,7 @@
 package com.sanctionco.thunder.crypto;
 
 /**
- * Provides the simple implementation for the {@link HashService}.  Provides methods to hash and to
+ * Provides a simple implementation for the {@link HashService}. Provides methods to hash and to
  * verify existing hashes match. This implementation can be used to compare without actually
  * performing a hash.
  *

--- a/application/src/main/java/com/sanctionco/thunder/crypto/SimpleHashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/SimpleHashService.java
@@ -7,7 +7,11 @@ package com.sanctionco.thunder.crypto;
  *
  * @see HashService
  */
-public class SimpleHashService implements HashService {
+public class SimpleHashService extends HashService {
+
+  SimpleHashService(boolean serverSideHashEnabled) {
+    super(serverSideHashEnabled);
+  }
 
   @Override
   public boolean isMatch(String plaintext, String hashed) {

--- a/application/src/main/java/com/sanctionco/thunder/crypto/SimpleHashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/SimpleHashService.java
@@ -1,8 +1,8 @@
 package com.sanctionco.thunder.crypto;
 
 /**
- * Provides the simple implementation for the {@link HashService}. Provides a method that is used
- * to verify that hashed strings match. This implementation can be used to compare without actually
+ * Provides the simple implementation for the {@link HashService}.  Provides methods to hash and to
+ * verify existing hashes match. This implementation can be used to compare without actually
  * performing a hash.
  *
  * @see HashService
@@ -12,5 +12,10 @@ public class SimpleHashService implements HashService {
   @Override
   public boolean isMatch(String plaintext, String hashed) {
     return plaintext.equals(hashed);
+  }
+
+  @Override
+  public String hash(String plaintext) {
+    return plaintext;
   }
 }

--- a/application/src/main/java/com/sanctionco/thunder/resources/UserResource.java
+++ b/application/src/main/java/com/sanctionco/thunder/resources/UserResource.java
@@ -105,10 +105,13 @@ public class UserResource {
 
     LOG.info("Attempting to create new user {}.", user.getEmail().getAddress());
 
+    // Hash the user's password
+    String finalPassword = hashService.hash(user.getPassword());
+
     // Update the user to non-verified status
     User updatedUser = new User(
         new Email(user.getEmail().getAddress(), false, null),
-        user.getPassword(),
+        finalPassword,
         user.getProperties());
 
     User result;
@@ -178,12 +181,19 @@ public class UserResource {
         ? foundUser.getEmail().getVerificationToken()
         : null;
 
+    // Hash the password if it is a new password
+    String finalPassword = foundUser.getPassword();
+
+    if (!hashService.isMatch(user.getPassword(), foundUser.getPassword())) {
+      finalPassword = hashService.hash(user.getPassword());
+    }
+
     LOG.info("Using verified status: {} and token: {} for the updated user.",
         verified, verificationToken);
 
     User updatedUser = new User(
         new Email(user.getEmail().getAddress(), verified, verificationToken),
-        user.getPassword(),
+        finalPassword,
         user.getProperties());
 
     User result;

--- a/application/src/test/java/com/sanctionco/thunder/ThunderConfigurationTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/ThunderConfigurationTest.java
@@ -61,8 +61,9 @@ class ThunderConfigurationTest {
         new PropertyValidationRule("testProperty", "list"),
         configuration.getValidationRules().get(0));
 
-    // This config should use the default hash algorithm (Simple)
+    // This config should use the default hash configuration
     assertEquals(HashAlgorithm.SIMPLE, configuration.getHashConfiguration().getAlgorithm());
+    assertFalse(configuration.getHashConfiguration().serverSideHash());
   }
 
   @Test

--- a/application/src/test/java/com/sanctionco/thunder/crypto/BCryptHashServiceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/crypto/BCryptHashServiceTest.java
@@ -2,11 +2,12 @@ package com.sanctionco.thunder.crypto;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BCryptHashServiceTest {
-  private final HashService hashService = new BCryptHashService();
+  private final HashService hashService = new BCryptHashService(true);
 
   @Test
   void testHashMatch() {
@@ -52,5 +53,15 @@ class BCryptHashServiceTest {
 
     assertFalse(hashService.isMatch(plaintext, secondResult));
     assertFalse(hashService.isMatch(secondPlaintext, result));
+  }
+
+  @Test
+  void testServerSideHashDisabled() {
+    HashService hashService = new BCryptHashService(false);
+
+    String plaintext = "password";
+    String result = hashService.hash(plaintext);
+
+    assertEquals(plaintext, result);
   }
 }

--- a/application/src/test/java/com/sanctionco/thunder/crypto/BCryptHashServiceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/crypto/BCryptHashServiceTest.java
@@ -23,4 +23,34 @@ class BCryptHashServiceTest {
 
     assertFalse(hashService.isMatch(plaintext, hashed));
   }
+
+  @Test
+  void testHashSame() {
+    String plaintext = "password";
+    String secondPlaintext = "password";
+
+    String result = hashService.hash(plaintext);
+    String secondResult = hashService.hash(secondPlaintext);
+
+    assertTrue(hashService.isMatch(plaintext, result));
+    assertTrue(hashService.isMatch(secondPlaintext, secondResult));
+
+    assertTrue(hashService.isMatch(plaintext, secondResult));
+    assertTrue(hashService.isMatch(secondPlaintext, result));
+  }
+
+  @Test
+  void testHashDifferent() {
+    String plaintext = "password";
+    String secondPlaintext = "secondPassword";
+
+    String result = hashService.hash(plaintext);
+    String secondResult = hashService.hash(secondPlaintext);
+
+    assertTrue(hashService.isMatch(plaintext, result));
+    assertTrue(hashService.isMatch(secondPlaintext, secondResult));
+
+    assertFalse(hashService.isMatch(plaintext, secondResult));
+    assertFalse(hashService.isMatch(secondPlaintext, result));
+  }
 }

--- a/application/src/test/java/com/sanctionco/thunder/crypto/HashAlgorithmTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/crypto/HashAlgorithmTest.java
@@ -14,7 +14,7 @@ class HashAlgorithmTest {
         () -> assertEquals(HashAlgorithm.BCRYPT, HashAlgorithm.fromString("bcrypt")),
         () -> assertEquals("bcrypt", HashAlgorithm.BCRYPT.toString()),
         () -> assertEquals(BCryptHashService.class,
-            HashAlgorithm.BCRYPT.newHashService().getClass()));
+            HashAlgorithm.BCRYPT.newHashService(false).getClass()));
   }
 
   @Test
@@ -23,7 +23,7 @@ class HashAlgorithmTest {
         () -> assertEquals(HashAlgorithm.MD5, HashAlgorithm.fromString("md5")),
         () -> assertEquals("md5", HashAlgorithm.MD5.toString()),
         () -> assertEquals(MD5HashService.class,
-            HashAlgorithm.MD5.newHashService().getClass()));
+            HashAlgorithm.MD5.newHashService(false).getClass()));
   }
 
   @Test
@@ -32,7 +32,7 @@ class HashAlgorithmTest {
         () -> assertEquals(HashAlgorithm.SIMPLE, HashAlgorithm.fromString("simple")),
         () -> assertEquals("simple", HashAlgorithm.SIMPLE.toString()),
         () -> assertEquals(SimpleHashService.class,
-            HashAlgorithm.SIMPLE.newHashService().getClass()));
+            HashAlgorithm.SIMPLE.newHashService(false).getClass()));
   }
 
   @Test

--- a/application/src/test/java/com/sanctionco/thunder/crypto/MD5HashServiceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/crypto/MD5HashServiceTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MD5HashServiceTest {
-  private final HashService hashService = new MD5HashService();
+  private final HashService hashService = new MD5HashService(false);
 
   @Test
   void testHashMatch() {
@@ -46,5 +46,15 @@ class MD5HashServiceTest {
     String secondResult = hashService.hash(secondPlaintext);
 
     assertNotEquals(result, secondResult);
+  }
+
+  @Test
+  void testServerSideHashDisabled() {
+    HashService hashService = new MD5HashService(false);
+
+    String plaintext = "password";
+    String result = hashService.hash(plaintext);
+
+    assertEquals(plaintext, result);
   }
 }

--- a/application/src/test/java/com/sanctionco/thunder/crypto/MD5HashServiceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/crypto/MD5HashServiceTest.java
@@ -2,7 +2,9 @@ package com.sanctionco.thunder.crypto;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MD5HashServiceTest {
@@ -22,5 +24,27 @@ class MD5HashServiceTest {
     String hashed = "5e9d11a14ad1c8dd77e98ef9b53fd1ba";
 
     assertFalse(hashService.isMatch(plaintext, hashed));
+  }
+
+  @Test
+  void testHashSame() {
+    String plaintext = "password";
+    String secondPlaintext = "password";
+
+    String result = hashService.hash(plaintext);
+    String secondResult = hashService.hash(secondPlaintext);
+
+    assertEquals(result, secondResult);
+  }
+
+  @Test
+  void testHashDifferent() {
+    String plaintext = "password";
+    String secondPlaintext = "secondPassword";
+
+    String result = hashService.hash(plaintext);
+    String secondResult = hashService.hash(secondPlaintext);
+
+    assertNotEquals(result, secondResult);
   }
 }

--- a/application/src/test/java/com/sanctionco/thunder/crypto/SimpleHashServiceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/crypto/SimpleHashServiceTest.java
@@ -2,7 +2,9 @@ package com.sanctionco.thunder.crypto;
 
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SimpleHashServiceTest {
@@ -22,5 +24,33 @@ class SimpleHashServiceTest {
     String hashed = "5e9d11a14ad1c8dd77e98ef9b53fd1ba";
 
     assertFalse(hashService.isMatch(plaintext, hashed));
+  }
+
+  @Test
+  void testHashSame() {
+    String plaintext = "password";
+    String secondPlaintext = "password";
+
+    String result = hashService.hash(plaintext);
+    String secondResult = hashService.hash(secondPlaintext);
+
+    assertEquals(plaintext, result);
+    assertEquals(secondPlaintext, secondResult);
+
+    assertEquals(result, secondResult);
+  }
+
+  @Test
+  void testHashDifferent() {
+    String plaintext = "password";
+    String secondPlaintext = "secondPassword";
+
+    String result = hashService.hash(plaintext);
+    String secondResult = hashService.hash(secondPlaintext);
+
+    assertEquals(plaintext, result);
+    assertEquals(secondPlaintext, secondResult);
+
+    assertNotEquals(result, secondResult);
   }
 }

--- a/application/src/test/java/com/sanctionco/thunder/crypto/SimpleHashServiceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/crypto/SimpleHashServiceTest.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SimpleHashServiceTest {
-  private final HashService hashService = new SimpleHashService();
+  private final HashService hashService = new SimpleHashService(false);
 
   @Test
   void testHashMatch() {

--- a/application/src/test/java/com/sanctionco/thunder/resources/UserResourceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/resources/UserResourceTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.AdditionalAnswers.returnsSecondArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -120,6 +121,26 @@ class UserResourceTest {
     assertAll("Assert successful user creation",
         () -> assertEquals(Response.Status.CREATED, response.getStatusInfo()),
         () -> assertEquals(updatedUser, result));
+  }
+
+  @Test
+  void testPostUserServerSideHash() {
+    HashService hashService = HashAlgorithm.MD5.newHashService(true);
+    UserResource resource = new UserResource(usersDao, validator, hashService, metrics);
+
+    when(usersDao.insert(any(User.class))).then(returnsFirstArg());
+
+    User expectedUser = new User(
+        new Email("test@test.com", false, null),
+        "5f4dcc3b5aa765d61d8327deb882cf99",
+        Collections.emptyMap());
+
+    Response response = resource.postUser(key, user);
+    User result = (User) response.getEntity();
+
+    assertAll("Assert successful user creation and password hash",
+        () -> assertEquals(Response.Status.CREATED, response.getStatusInfo()),
+        () -> assertEquals(expectedUser, result));
   }
 
   @Test
@@ -286,6 +307,70 @@ class UserResourceTest {
     User result = (User) response.getEntity();
 
     assertAll("Assert successful user update with new email",
+        () -> assertEquals(Response.Status.OK, response.getStatusInfo()),
+        () -> assertEquals(expectedResponse, result));
+  }
+
+  @Test
+  void testUpdateUserServerSideHash() {
+    HashService hashService = HashAlgorithm.MD5.newHashService(true);
+    UserResource resource = new UserResource(usersDao, validator, hashService, metrics);
+
+    // Set up the user that should already exist in the database
+    Email existingEmail = new Email("existing@test.com", true, "token");
+    User existingUser = new User(existingEmail, "5f4dcc3b5aa765d61d8327deb882cf99",
+        Collections.emptyMap());
+
+    when(usersDao.findByEmail(existingEmail.getAddress())).thenReturn(existingUser);
+    when(usersDao.update(eq(null), any(User.class))).then(returnsSecondArg());
+
+    // Define the updated user with changed password
+    User updatedUser = new User(
+        new Email(existingEmail.getAddress(), true, "token"),
+        "newPassword",
+        Collections.emptyMap());
+
+    // Expect that the new password is hashed with MD5
+    User expectedResponse = new User(
+        new Email(updatedUser.getEmail().getAddress(), true, "token"),
+        "14a88b9d2f52c55b5fbcf9c5d9c11875", updatedUser.getProperties());
+
+    Response response = resource.updateUser(key, "password", null, updatedUser);
+    User result = (User) response.getEntity();
+
+    assertAll("Assert successful user update",
+        () -> assertEquals(Response.Status.OK, response.getStatusInfo()),
+        () -> assertEquals(expectedResponse, result));
+  }
+
+  @Test
+  void testUpdateUserServerSideHashNoPasswordChange() {
+    HashService hashService = HashAlgorithm.MD5.newHashService(true);
+    UserResource resource = new UserResource(usersDao, validator, hashService, metrics);
+
+    // Set up the user that should already exist in the database
+    Email existingEmail = new Email("existing@test.com", true, "token");
+    User existingUser = new User(existingEmail, "5f4dcc3b5aa765d61d8327deb882cf99",
+        Collections.emptyMap());
+
+    when(usersDao.findByEmail(existingEmail.getAddress())).thenReturn(existingUser);
+    when(usersDao.update(eq(null), any(User.class))).then(returnsSecondArg());
+
+    // Define the updated user with the same password
+    User updatedUser = new User(
+        new Email(existingEmail.getAddress(), true, "token"),
+        "password",
+        Collections.singletonMap("ID", 80));
+
+    // Expect that the password stays the same
+    User expectedResponse = new User(
+        new Email(updatedUser.getEmail().getAddress(), true, "token"),
+        "5f4dcc3b5aa765d61d8327deb882cf99", updatedUser.getProperties());
+
+    Response response = resource.updateUser(key, "password", null, updatedUser);
+    User result = (User) response.getEntity();
+
+    assertAll("Assert successful user update",
         () -> assertEquals(Response.Status.OK, response.getStatusInfo()),
         () -> assertEquals(expectedResponse, result));
   }

--- a/application/src/test/java/com/sanctionco/thunder/resources/UserResourceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/resources/UserResourceTest.java
@@ -3,8 +3,8 @@ package com.sanctionco.thunder.resources;
 import com.codahale.metrics.MetricRegistry;
 
 import com.sanctionco.thunder.authentication.Key;
+import com.sanctionco.thunder.crypto.HashAlgorithm;
 import com.sanctionco.thunder.crypto.HashService;
-import com.sanctionco.thunder.crypto.SimpleHashService;
 import com.sanctionco.thunder.dao.DatabaseError;
 import com.sanctionco.thunder.dao.DatabaseException;
 import com.sanctionco.thunder.dao.UsersDao;
@@ -34,7 +34,7 @@ class UserResourceTest {
   private final User user = new User(email, "password", Collections.emptyMap());
   private final User updatedUser = new User(email, "newPassword", Collections.emptyMap());
 
-  private final HashService hashService = new SimpleHashService();
+  private final HashService hashService = HashAlgorithm.SIMPLE.newHashService(false);
 
   private final UsersDao usersDao = mock(UsersDao.class);
   private final MetricRegistry metrics = new MetricRegistry();

--- a/application/src/test/java/com/sanctionco/thunder/resources/VerificationResourceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/resources/VerificationResourceTest.java
@@ -3,8 +3,8 @@ package com.sanctionco.thunder.resources;
 import com.codahale.metrics.MetricRegistry;
 
 import com.sanctionco.thunder.authentication.Key;
+import com.sanctionco.thunder.crypto.HashAlgorithm;
 import com.sanctionco.thunder.crypto.HashService;
-import com.sanctionco.thunder.crypto.SimpleHashService;
 import com.sanctionco.thunder.dao.DatabaseError;
 import com.sanctionco.thunder.dao.DatabaseException;
 import com.sanctionco.thunder.dao.UsersDao;
@@ -41,7 +41,7 @@ class VerificationResourceTest {
   private static final String VERIFICATION_HTML = "<html>Verify</html>";
   private static final String VERIFICATION_TEXT = "Verify";
 
-  private final HashService hashService = new SimpleHashService();
+  private final HashService hashService = HashAlgorithm.SIMPLE.newHashService(false);
   private final EmailService emailService = mock(EmailService.class);
   private final MetricRegistry metrics = new MetricRegistry();
   private final UsersDao usersDao = mock(UsersDao.class);

--- a/docs/manual/configuration-options.rst
+++ b/docs/manual/configuration-options.rst
@@ -122,6 +122,32 @@ application                         **REQUIRED**                        The name
 secret                              **REQUIRED**                        The secret of the approved application (basic authentication password).
 =================================== ==================================  =============================================================================
 
+.. _configuration-hash:
+
+User Password Hashing
+=====================
+
+This configuration object is **OPTIONAL**.
+
+This group of options allows you to configure the hashing algorithm used by Thunder for server-side hashing of
+user passwords, as well as the algorithm used to check the password value in the request header.
+
+.. code-block:: yaml
+
+    passwordHash:
+      algorithm:
+      serverSideHash:
+
+
+=================================== ==================================  =============================================================================
+Name                                Default                             Description
+=================================== ==================================  =============================================================================
+algorithm                           simple                              The algorithm to use for server side hashing and password comparison.
+                                                                        Supported values are: ``simple``, ``md5``, and ``bcrypt``.
+serverSideHash                      false                               Whether or not to enable server side hashing. When enabled, a new user or
+                                                                        updated password will be hashed within Thunder before being stored in the database.
+=================================== ==================================  =============================================================================
+
 .. _configuration-properties:
 
 Property Validation

--- a/docs/manual/user-attributes.rst
+++ b/docs/manual/user-attributes.rst
@@ -11,7 +11,7 @@ Exposed Attributes
 
 - ``email`` The email for the user, represented as a string. This is always required, as it is the unique identifier for a user.
 
-- ``password`` The user's password as a string. This is always required, and will always be passed around as a hashed version of the actual password. The only time the password should be plain text is when the user types it in right before it gets hashed.
+- ``password`` The user's password as a string. This is always required, and will be stored as a hashed version of the actual password.
 
 - ``properties`` A map of additional user properties. These can be anything you wish, using a `String` as the identifier and any object type as the value. Properties can be validated on `POST`/`PUT` by enabling :ref:`configuration-properties`.
 

--- a/scripts/tests/bcrypt/config.yaml
+++ b/scripts/tests/bcrypt/config.yaml
@@ -18,6 +18,7 @@ approvedKeys:
 # Use BCrypt for password hashing
 passwordHash:
   algorithm: bcrypt
+  serverSideHash: true
 
 # Server configuration
 server:

--- a/scripts/tests/bcrypt/tests.yaml
+++ b/scripts/tests/bcrypt/tests.yaml
@@ -7,14 +7,14 @@
   body:
     email:
       address: success@simulator.amazonses.com
-    password: $2a$04$R2O9.KYUOlsU.mObpUXuQOtONTyBVNkuzEP0d2Hn3tkwR7wIJxNnC
+    password: password
   expectedCode: 201
   expectedResponse:
     email:
       address: success@simulator.amazonses.com
       verified: false
       verificationToken: null
-    password: $2a$04$R2O9.KYUOlsU.mObpUXuQOtONTyBVNkuzEP0d2Hn3tkwR7wIJxNnC
+    password: HASHED
     properties: {}
 
 # GET
@@ -29,7 +29,7 @@
       address: success@simulator.amazonses.com
       verified: false
       verificationToken: null
-    password: $2a$04$R2O9.KYUOlsU.mObpUXuQOtONTyBVNkuzEP0d2Hn3tkwR7wIJxNnC
+    password: HASHED
     properties: {}
 
 # EMAIL
@@ -44,7 +44,7 @@
       address: success@simulator.amazonses.com
       verified: false
       verificationToken: GENERATED
-    password: $2a$04$R2O9.KYUOlsU.mObpUXuQOtONTyBVNkuzEP0d2Hn3tkwR7wIJxNnC
+    password: HASHED
     properties: {}
 
 # VERIFY
@@ -60,7 +60,7 @@
       address: success@simulator.amazonses.com
       verified: true
       verificationToken: GENERATED
-    password: $2a$04$R2O9.KYUOlsU.mObpUXuQOtONTyBVNkuzEP0d2Hn3tkwR7wIJxNnC
+    password: HASHED
     properties: {}
 
 # UPDATE
@@ -74,14 +74,14 @@
       address: success@simulator.amazonses.com
       verified: true
       verificationToken: GENERATED
-    password: $2a$10$yPGNyRwvZM0CxR9audvL.uB2DhJstvJZ7MYoiGEHDgw0RhzWwIkQe
+    password: newpassword
   expectedCode: 200
   expectedResponse:
     email:
       address: success@simulator.amazonses.com
       verified: true
       verificationToken: GENERATED
-    password: $2a$10$yPGNyRwvZM0CxR9audvL.uB2DhJstvJZ7MYoiGEHDgw0RhzWwIkQe
+    password: HASHED
     properties: {}
 
 # GET
@@ -96,7 +96,7 @@
       address: success@simulator.amazonses.com
       verified: true
       verificationToken: GENERATED
-    password: $2a$10$yPGNyRwvZM0CxR9audvL.uB2DhJstvJZ7MYoiGEHDgw0RhzWwIkQe
+    password: HASHED
     properties: {}
 
 # DELETE
@@ -111,5 +111,5 @@
       address: success@simulator.amazonses.com
       verified: true
       verificationToken: GENERATED
-    password: $2a$10$yPGNyRwvZM0CxR9audvL.uB2DhJstvJZ7MYoiGEHDgw0RhzWwIkQe
+    password: HASHED
     properties: {}

--- a/scripts/tests/md5/config.yaml
+++ b/scripts/tests/md5/config.yaml
@@ -18,6 +18,7 @@ approvedKeys:
 # Use MD5 for password hashing
 passwordHash:
   algorithm: md5
+  serverSideHash: true
 
 # Server configuration
 server:

--- a/scripts/tests/md5/tests.yaml
+++ b/scripts/tests/md5/tests.yaml
@@ -7,7 +7,7 @@
   body:
     email:
       address: success@simulator.amazonses.com
-    password: 5f4dcc3b5aa765d61d8327deb882cf99
+    password: password
   expectedCode: 201
   expectedResponse:
     email:
@@ -74,7 +74,7 @@
       address: success@simulator.amazonses.com
       verified: true
       verificationToken: GENERATED
-    password: 5e9d11a14ad1c8dd77e98ef9b53fd1ba
+    password: newpassword
   expectedCode: 200
   expectedResponse:
     email:

--- a/scripts/tests/test-runner.js
+++ b/scripts/tests/test-runner.js
@@ -127,6 +127,12 @@ function getCallback(test, callback) {
       test.expectedResponse.email.verificationToken = result.email.verificationToken;
     }
 
+    if (test.expectedResponse.password
+      && test.expectedResponse.password === 'HASHED') {
+      // If the test expects the hashed password value, replace it
+      test.expectedResponse.password = result.password;
+    }
+
     const err = responseHandler.handleResponse(error, statusCode, result,
         test.name, test.expectedCode, test.expectedResponse, args.verbose);
 


### PR DESCRIPTION
### This PR addresses:
<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists. -->
#258.

- Adds a new configuration option to enable server-side hashing. This option is disabled by default to maintain backwards compatibility. (We will likely switch this to enabled by default in v3.0).
- When enabled, performs password hashing based on the defined algorithm when a user is created or when a user's password is updated.

### I have verified that:
<!-- Ensure all of these boxes are checked. -->
- [x] All related unit tests have been updated/created
- [x] All related integration tests have been updated/created
- [x] I have updated relevant documentation in the `docs/` directory

### Additional Notes
<!-- Put any other additional notes here for reviewers. -->