### PR TITLE
Switch to openjdk8 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 # Cache Maven and Node dependencies
 cache:


### PR DESCRIPTION
### This PR addresses:
<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists. -->
The Travis builds are now failing for oraclejdk8, possibly due to licensing changes. This changes it to openjdk8.

### I have verified that:
<!-- Ensure all of these boxes are checked. -->
- [x] All related unit tests have been updated/created
- [x] All related integration tests have been updated/created
- [x] I have updated relevant documentation in the `docs/` directory

### Additional Notes
<!-- Put any other additional notes here for reviewers. -->
