### PR TITLE
Populate Swagger version number during build

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -59,6 +59,13 @@
         <artifactId>jacoco-maven-plugin</artifactId>
       </plugin>
     </plugins>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
   </build>
 
   <dependencies>

--- a/application/src/main/java/com/sanctionco/thunder/openapi/OpenApiConfiguration.java
+++ b/application/src/main/java/com/sanctionco/thunder/openapi/OpenApiConfiguration.java
@@ -3,6 +3,7 @@ package com.sanctionco.thunder.openapi;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.io.Resources;
 
 import io.swagger.v3.oas.integration.SwaggerConfiguration;
 import io.swagger.v3.oas.models.ExternalDocumentation;
@@ -14,6 +15,8 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.tags.Tag;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +38,7 @@ public class OpenApiConfiguration {
   private static final Set<String> RESOURCES
       = Collections.singleton("com.sanctionco.thunder.resources");
   private static final String DEFAULT_TITLE = "Thunder API";
-  private static final String DEFAULT_VERSION = "3.0.0";
+  private static final String DEFAULT_VERSION_FILE = "version.txt";
   private static final String DEFAULT_DESCRIPTION = "A fully customizable user management REST API";
   private static final String DEFAULT_LICENSE = "MIT";
   private static final String DEFAULT_LICENSE_URL
@@ -48,7 +51,7 @@ public class OpenApiConfiguration {
     this.enabled = true;
 
     this.title = DEFAULT_TITLE;
-    this.version = DEFAULT_VERSION;
+    this.version = readFileAsResources(DEFAULT_VERSION_FILE);
     this.description = DEFAULT_DESCRIPTION;
     this.license = DEFAULT_LICENSE;
     this.licenseUrl = DEFAULT_LICENSE_URL;
@@ -71,7 +74,7 @@ public class OpenApiConfiguration {
     return title;
   }
 
-  @JsonProperty("version")
+  @JsonIgnore
   private final String version;
 
   public String getVersion() {
@@ -152,5 +155,22 @@ public class OpenApiConfiguration {
         .readAllResources(true)
         .ignoredRoutes(exclusions)
         .resourcePackages(RESOURCES);
+  }
+
+  /**
+   * Reads a file from the resources folder.
+   *
+   * @param fileName the name of the file
+   * @return the file's contents
+   * @throws IllegalStateException if the file was not found or there was an error reading the file
+   */
+  private String readFileAsResources(String fileName) {
+    try {
+      return Resources.toString(Resources.getResource(fileName), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new IllegalStateException("Error reading default version from resources folder", e);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalStateException("Default version not found in resources folder", e);
+    }
   }
 }

--- a/application/src/main/resources/version.txt
+++ b/application/src/main/resources/version.txt
@@ -1,0 +1,1 @@
+${project.version}

--- a/application/src/test/java/com/sanctionco/thunder/openapi/OpenApiConfigurationTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/openapi/OpenApiConfigurationTest.java
@@ -9,6 +9,7 @@ import io.dropwizard.jersey.validation.Validators;
 import io.swagger.v3.oas.integration.SwaggerConfiguration;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 import javax.validation.Validator;
 
@@ -31,10 +32,13 @@ class OpenApiConfigurationTest {
     OpenApiConfiguration configuration = FACTORY.build(new File(Resources.getResource(
         "fixtures/configuration/openapi/valid-config.yaml").toURI()));
 
+    String expectedVersion = Resources.toString(Resources.getResource("version.txt"),
+        StandardCharsets.UTF_8);
+
     assertAll("OpenAPI configuration is correct",
         () -> assertFalse(configuration.isEnabled()),
         () -> assertEquals("Test Title", configuration.getTitle()),
-        () -> assertEquals("100.0.0", configuration.getVersion()),
+        () -> assertEquals(expectedVersion, configuration.getVersion()),
         () -> assertEquals("Test Description", configuration.getDescription()),
         () -> assertEquals("Test Contact Name", configuration.getContact()),
         () -> assertEquals("Test Contact Email", configuration.getContactEmail()),
@@ -48,10 +52,13 @@ class OpenApiConfigurationTest {
     OpenApiConfiguration configuration = FACTORY.build(new File(Resources.getResource(
         "fixtures/configuration/openapi/only-title.yaml").toURI()));
 
+    String expectedVersion = Resources.toString(Resources.getResource("version.txt"),
+        StandardCharsets.UTF_8);
+
     assertAll("OpenAPI configuration is correct",
         () -> assertTrue(configuration.isEnabled()),
         () -> assertEquals("My New Title", configuration.getTitle()),
-        () -> assertEquals("3.0.0", configuration.getVersion()),
+        () -> assertEquals(expectedVersion, configuration.getVersion()),
         () -> assertEquals("A fully customizable user management REST API",
             configuration.getDescription()),
         () -> assertNull(configuration.getContact()),


### PR DESCRIPTION
### This PR addresses:
<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists. -->
Closes #895. Uses Maven's resource filtering feature to replace the `version.txt` file contents with the current version of the project. We then read the `version.txt` file within the `OpenApiConfiguration` java class in order to have the correct version in the swagger resource.

### I have verified that:
<!-- Ensure all of these boxes are checked. -->
- [x] All related unit tests have been updated/created
- [x] All related integration tests have been updated/created
- [x] I have updated relevant documentation in the `docs/` directory

### Additional Notes
<!-- Put any other additional notes here for reviewers. -->
