### PR TITLE
Upgrade xstream version within nexus plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,15 @@
               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
               <autoReleaseAfterClose>true</autoReleaseAfterClose>
             </configuration>
+            <!-- TODO: Remove after OSSRH-66257, NEXUS-26993 are fixed,
+                 possibly via https://github.com/sonatype/nexus-maven-plugins/pull/91 -->
+            <dependencies>
+              <dependency>
+                <groupId>com.thoughtworks.xstream</groupId>
+                <artifactId>xstream</artifactId>
+                <version>1.4.15</version>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
### This PR addresses:
<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists. -->
Works around the issue in Java 16+ with releasing so that we don't have to specify `MAVEN_OPTS`

### I have verified that:
<!-- Ensure all of these boxes are checked. -->
- [x] All related unit tests have been updated/created
- [x] All related integration tests have been updated/created
- [x] I have updated any relevant documentation in the `docs/` directory
- [x] If I made any additions/changes to the config file, I've updated the Helm chart in `scripts/deploy/helm`
- [x] If necessary, I've updated `CHANGELOG.md` with a description of my change

### Additional Notes
<!-- Put any other additional notes here for reviewers. -->
