### PR TITLE
Replace internal bcrypt hash implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,6 @@ jobs:
       with:
         directory: .
 
-    # - name: Run itegration tests without Docker
-    #   run: sh -c scripts/tools/integration-tests.sh
-
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
         value: 'my.domain.com'
   ```
 
+## ⚛ Fixed
+* Sha256 password hashing no longer logs the generated salt.
+
 ## ☕ Client
 * Added a new constructor for the `User` object in the Java API module that allows construction
   without specifying a property map (an empty map will be created by default).

--- a/application/pom.xml
+++ b/application/pom.xml
@@ -70,10 +70,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>at.favre.lib</groupId>
-      <artifactId>bcrypt</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>java-jwt</artifactId>
     </dependency>
@@ -84,6 +80,10 @@
     <dependency>
       <groupId>com.google.dagger</groupId>
       <artifactId>dagger-compiler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.password4j</groupId>
+      <artifactId>password4j</artifactId>
     </dependency>
     <dependency>
       <groupId>com.sanctionco.jmail</groupId>

--- a/application/src/main/java/com/sanctionco/thunder/crypto/BCryptHashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/BCryptHashService.java
@@ -1,6 +1,6 @@
 package com.sanctionco.thunder.crypto;
 
-import at.favre.lib.crypto.bcrypt.BCrypt;
+import com.password4j.Password;
 
 /**
  * Provides the BCrypt implementation for the {@link HashService}. Provides methods to hash and to
@@ -16,13 +16,13 @@ public class BCryptHashService extends HashService {
 
   @Override
   boolean isMatchExact(String plaintext, String hashed) {
-    return BCrypt.verifyer().verify(plaintext.getBytes(), hashed.getBytes()).verified;
+    return Password.check(plaintext, hashed).withBcrypt();
   }
 
   @Override
   public String hash(String plaintext) {
     if (serverSideHashEnabled()) {
-      return BCrypt.withDefaults().hashToString(10, plaintext.toCharArray());
+      return Password.hash(plaintext).withBcrypt().getResult();
     }
 
     return plaintext;

--- a/application/src/main/java/com/sanctionco/thunder/crypto/Sha256HashService.java
+++ b/application/src/main/java/com/sanctionco/thunder/crypto/Sha256HashService.java
@@ -2,9 +2,6 @@ package com.sanctionco.thunder.crypto;
 
 import com.sanctionco.thunder.util.HashUtilities;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /**
  * Provides the MD5 implementation for the {@link HashService}. Provides methods to hash and to
  * verify existing hashes match.
@@ -12,7 +9,6 @@ import org.slf4j.LoggerFactory;
  * @see HashService
  */
 public class Sha256HashService extends HashService {
-  private static final Logger LOG = LoggerFactory.getLogger(Sha256HashService.class);
   private static final int SALT_LENGTH = 16;
 
   Sha256HashService(boolean serverSideHashEnabled, boolean allowCommonMistakes) {
@@ -37,8 +33,6 @@ public class Sha256HashService extends HashService {
 
     var salt = generateSalt(SALT_LENGTH);
     var hashed = HashUtilities.performHash("SHA-256", salt + plaintext).toLowerCase();
-
-    LOG.info("Generated salt {} of length {} when performing SHA-256 hash.", salt, salt.length());
 
     return salt + hashed;
   }

--- a/application/src/test/java/com/sanctionco/thunder/crypto/BCryptHashServiceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/crypto/BCryptHashServiceTest.java
@@ -2,7 +2,6 @@ package com.sanctionco.thunder.crypto;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -23,110 +22,5 @@ class BCryptHashServiceTest {
     String hashed = "$2a$10$DeRCO2XcQ4IDZ19LikkaZOgl5eQWozWPJTCtSf1nJFjNEINR.ZOru";
 
     assertFalse(hashService.isMatch(plaintext, hashed));
-  }
-
-  @Test
-  void testHashSame() {
-    String plaintext = "password";
-    String secondPlaintext = "password";
-
-    String result = hashService.hash(plaintext);
-    String secondResult = hashService.hash(secondPlaintext);
-
-    assertTrue(hashService.isMatch(plaintext, result));
-    assertTrue(hashService.isMatch(secondPlaintext, secondResult));
-
-    assertTrue(hashService.isMatch(plaintext, secondResult));
-    assertTrue(hashService.isMatch(secondPlaintext, result));
-  }
-
-  @Test
-  void testHashDifferent() {
-    String plaintext = "password";
-    String secondPlaintext = "secondPassword";
-
-    String result = hashService.hash(plaintext);
-    String secondResult = hashService.hash(secondPlaintext);
-
-    assertTrue(hashService.isMatch(plaintext, result));
-    assertTrue(hashService.isMatch(secondPlaintext, secondResult));
-
-    assertFalse(hashService.isMatch(plaintext, secondResult));
-    assertFalse(hashService.isMatch(secondPlaintext, result));
-  }
-
-  @Test
-  void testHashWithMistakesDisabled() {
-    String plaintext = "Password";
-    String hashed = hashService.hash(plaintext);
-
-    assertTrue(hashService.isMatch(plaintext, hashed));
-
-    String capsLock = "pASSWORD";
-    assertFalse(hashService.isMatch(capsLock, hashed));
-
-    String extraFirstCharacter = "*Password";
-    assertFalse(hashService.isMatch(extraFirstCharacter, hashed));
-
-    String extraLastCharacter = "Password-";
-    assertFalse(hashService.isMatch(extraLastCharacter, hashed));
-
-    String firstCharacterCaseSwap = "password";
-    assertFalse(hashService.isMatch(firstCharacterCaseSwap, hashed));
-  }
-
-  @Test
-  void testHashWithMistakesEnabled() {
-    HashService hashService = new BCryptHashService(true, true);
-
-    String plaintext = "Password";
-    String hashed = hashService.hash(plaintext);
-
-    assertTrue(hashService.isMatch(plaintext, hashed));
-
-    String capsLock = "pASSWORD";
-    assertTrue(hashService.isMatch(capsLock, hashed));
-
-    String extraFirstCharacter = "*Password";
-    assertTrue(hashService.isMatch(extraFirstCharacter, hashed));
-
-    String extraLastCharacter = "Password-";
-    assertTrue(hashService.isMatch(extraLastCharacter, hashed));
-
-    String firstCharacterCaseSwap = "password";
-    assertTrue(hashService.isMatch(firstCharacterCaseSwap, hashed));
-  }
-
-  @Test
-  void testHashWithMistakesEnabledIncorrect() {
-    HashService hashService = new BCryptHashService(true, true);
-
-    String plaintext = "Password";
-    String hashed = hashService.hash(plaintext);
-
-    assertTrue(hashService.isMatch(plaintext, hashed));
-
-    String incorrectCapsLock = "PASSWORD";
-    assertFalse(hashService.isMatch(incorrectCapsLock, hashed));
-
-    String incorrectExtraFirstCharacter = "*2Password";
-    assertFalse(hashService.isMatch(incorrectExtraFirstCharacter, hashed));
-
-    String incorrectExtraLastCharacter = "Password-x";
-    assertFalse(hashService.isMatch(incorrectExtraLastCharacter, hashed));
-
-    String incorrectFirstCharacterCaseSwap = "passworD";
-    assertFalse(hashService.isMatch(incorrectFirstCharacterCaseSwap, hashed));
-  }
-
-  @Test
-  void testServerSideHashDisabled() {
-    HashService hashService = new BCryptHashService(false, false);
-
-    String plaintext = "password";
-    String result = hashService.hash(plaintext);
-
-    // No hashing should be performed
-    assertEquals(plaintext, result);
   }
 }

--- a/application/src/test/java/com/sanctionco/thunder/crypto/HashServiceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/crypto/HashServiceTest.java
@@ -1,0 +1,128 @@
+package com.sanctionco.thunder.crypto;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class HashServiceTest {
+
+  @ParameterizedTest
+  @EnumSource(HashAlgorithm.class)
+  void testHashSame(HashAlgorithm algorithm) {
+    var hashService = algorithm.newHashService(true, false);
+
+    String plaintext = "password";
+    String secondPlaintext = "password";
+
+    String result = hashService.hash(plaintext);
+    String secondResult = hashService.hash(secondPlaintext);
+
+    assertTrue(hashService.isMatch(plaintext, result));
+    assertTrue(hashService.isMatch(secondPlaintext, secondResult));
+
+    assertTrue(hashService.isMatch(plaintext, secondResult));
+    assertTrue(hashService.isMatch(secondPlaintext, result));
+  }
+
+  @ParameterizedTest
+  @EnumSource(HashAlgorithm.class)
+  void testHashDifferent(HashAlgorithm algorithm) {
+    var hashService = algorithm.newHashService(true, false);
+
+    String plaintext = "password";
+    String secondPlaintext = "secondPassword";
+
+    String result = hashService.hash(plaintext);
+    String secondResult = hashService.hash(secondPlaintext);
+
+    assertTrue(hashService.isMatch(plaintext, result));
+    assertTrue(hashService.isMatch(secondPlaintext, secondResult));
+
+    assertFalse(hashService.isMatch(plaintext, secondResult));
+    assertFalse(hashService.isMatch(secondPlaintext, result));
+  }
+
+  @ParameterizedTest
+  @EnumSource(HashAlgorithm.class)
+  void testHashWithMistakesDisabled(HashAlgorithm algorithm) {
+    var hashService = algorithm.newHashService(true, false);
+
+    String plaintext = "Password";
+    String hashed = hashService.hash(plaintext);
+
+    assertTrue(hashService.isMatch(plaintext, hashed));
+
+    String capsLock = "pASSWORD";
+    assertFalse(hashService.isMatch(capsLock, hashed));
+
+    String extraFirstCharacter = "*Password";
+    assertFalse(hashService.isMatch(extraFirstCharacter, hashed));
+
+    String extraLastCharacter = "Password-";
+    assertFalse(hashService.isMatch(extraLastCharacter, hashed));
+
+    String firstCharacterCaseSwap = "password";
+    assertFalse(hashService.isMatch(firstCharacterCaseSwap, hashed));
+  }
+
+  @ParameterizedTest
+  @EnumSource(HashAlgorithm.class)
+  void testHashWithMistakesEnabled(HashAlgorithm algorithm) {
+    HashService hashService = algorithm.newHashService(true, true);
+
+    String plaintext = "Password";
+    String hashed = hashService.hash(plaintext);
+
+    assertTrue(hashService.isMatch(plaintext, hashed));
+
+    String capsLock = "pASSWORD";
+    assertTrue(hashService.isMatch(capsLock, hashed));
+
+    String extraFirstCharacter = "*Password";
+    assertTrue(hashService.isMatch(extraFirstCharacter, hashed));
+
+    String extraLastCharacter = "Password-";
+    assertTrue(hashService.isMatch(extraLastCharacter, hashed));
+
+    String firstCharacterCaseSwap = "password";
+    assertTrue(hashService.isMatch(firstCharacterCaseSwap, hashed));
+  }
+
+  @ParameterizedTest
+  @EnumSource(HashAlgorithm.class)
+  void testHashWithMistakesEnabledIncorrect(HashAlgorithm algorithm) {
+    HashService hashService = algorithm.newHashService(true, true);
+
+    String plaintext = "Password";
+    String hashed = hashService.hash(plaintext);
+
+    assertTrue(hashService.isMatch(plaintext, hashed));
+
+    String incorrectCapsLock = "PASSWORD";
+    assertFalse(hashService.isMatch(incorrectCapsLock, hashed));
+
+    String incorrectExtraFirstCharacter = "*2Password";
+    assertFalse(hashService.isMatch(incorrectExtraFirstCharacter, hashed));
+
+    String incorrectExtraLastCharacter = "Password-x";
+    assertFalse(hashService.isMatch(incorrectExtraLastCharacter, hashed));
+
+    String incorrectFirstCharacterCaseSwap = "passworD";
+    assertFalse(hashService.isMatch(incorrectFirstCharacterCaseSwap, hashed));
+  }
+
+  @ParameterizedTest
+  @EnumSource(HashAlgorithm.class)
+  void testServerSideHashDisabled(HashAlgorithm algorithm) {
+    HashService hashService = algorithm.newHashService(false, false);
+
+    String plaintext = "password";
+    String result = hashService.hash(plaintext);
+
+    // No hashing should be performed
+    assertEquals(plaintext, result);
+  }
+}

--- a/application/src/test/java/com/sanctionco/thunder/crypto/Sha256HashServiceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/crypto/Sha256HashServiceTest.java
@@ -2,7 +2,6 @@ package com.sanctionco.thunder.crypto;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -31,110 +30,5 @@ class Sha256HashServiceTest {
 
     assertFalse(hashService.isMatch(plaintext, hashed));
     assertFalse(hashService.isMatch(plaintext, uppercase));
-  }
-
-  @Test
-  void testHashSame() {
-    String plaintext = "password";
-    String secondPlaintext = "password";
-
-    String result = hashService.hash(plaintext);
-    String secondResult = hashService.hash(secondPlaintext);
-
-    assertTrue(hashService.isMatch(plaintext, result));
-    assertTrue(hashService.isMatch(secondPlaintext, secondResult));
-
-    assertTrue(hashService.isMatch(plaintext, secondResult));
-    assertTrue(hashService.isMatch(secondPlaintext, result));
-  }
-
-  @Test
-  void testHashDifferent() {
-    String plaintext = "password";
-    String secondPlaintext = "secondPassword";
-
-    String result = hashService.hash(plaintext);
-    String secondResult = hashService.hash(secondPlaintext);
-
-    assertTrue(hashService.isMatch(plaintext, result));
-    assertTrue(hashService.isMatch(secondPlaintext, secondResult));
-
-    assertFalse(hashService.isMatch(plaintext, secondResult));
-    assertFalse(hashService.isMatch(secondPlaintext, result));
-  }
-
-  @Test
-  void testHashWithMistakesDisabled() {
-    String plaintext = "Password";
-    String hashed = hashService.hash(plaintext);
-
-    assertTrue(hashService.isMatch(plaintext, hashed));
-
-    String capsLock = "pASSWORD";
-    assertFalse(hashService.isMatch(capsLock, hashed));
-
-    String extraFirstCharacter = "*Password";
-    assertFalse(hashService.isMatch(extraFirstCharacter, hashed));
-
-    String extraLastCharacter = "Password-";
-    assertFalse(hashService.isMatch(extraLastCharacter, hashed));
-
-    String firstCharacterCaseSwap = "password";
-    assertFalse(hashService.isMatch(firstCharacterCaseSwap, hashed));
-  }
-
-  @Test
-  void testHashWithMistakesEnabled() {
-    HashService hashService = new Sha256HashService(true, true);
-
-    String plaintext = "Password";
-    String hashed = hashService.hash(plaintext);
-
-    assertTrue(hashService.isMatch(plaintext, hashed));
-
-    String capsLock = "pASSWORD";
-    assertTrue(hashService.isMatch(capsLock, hashed));
-
-    String extraFirstCharacter = "*Password";
-    assertTrue(hashService.isMatch(extraFirstCharacter, hashed));
-
-    String extraLastCharacter = "Password-";
-    assertTrue(hashService.isMatch(extraLastCharacter, hashed));
-
-    String firstCharacterCaseSwap = "password";
-    assertTrue(hashService.isMatch(firstCharacterCaseSwap, hashed));
-  }
-
-  @Test
-  void testHashWithMistakesEnabledIncorrect() {
-    HashService hashService = new Sha256HashService(true, true);
-
-    String plaintext = "Password";
-    String hashed = hashService.hash(plaintext);
-
-    assertTrue(hashService.isMatch(plaintext, hashed));
-
-    String incorrectCapsLock = "PASSWORD";
-    assertFalse(hashService.isMatch(incorrectCapsLock, hashed));
-
-    String incorrectExtraFirstCharacter = "*2Password";
-    assertFalse(hashService.isMatch(incorrectExtraFirstCharacter, hashed));
-
-    String incorrectExtraLastCharacter = "Password-x";
-    assertFalse(hashService.isMatch(incorrectExtraLastCharacter, hashed));
-
-    String incorrectFirstCharacterCaseSwap = "passworD";
-    assertFalse(hashService.isMatch(incorrectFirstCharacterCaseSwap, hashed));
-  }
-
-  @Test
-  void testServerSideHashDisabled() {
-    HashService hashService = new Sha256HashService(false, false);
-
-    String plaintext = "password";
-    String result = hashService.hash(plaintext);
-
-    // No hashing should be performed
-    assertEquals(plaintext, result);
   }
 }

--- a/application/src/test/java/com/sanctionco/thunder/crypto/SimpleHashServiceTest.java
+++ b/application/src/test/java/com/sanctionco/thunder/crypto/SimpleHashServiceTest.java
@@ -2,9 +2,7 @@ package com.sanctionco.thunder.crypto;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SimpleHashServiceTest {
@@ -24,97 +22,5 @@ class SimpleHashServiceTest {
     String hashed = "5e9d11a14ad1c8dd77e98ef9b53fd1ba";
 
     assertFalse(hashService.isMatch(plaintext, hashed));
-  }
-
-  @Test
-  void testHashSame() {
-    String plaintext = "password";
-    String secondPlaintext = "password";
-
-    String result = hashService.hash(plaintext);
-    String secondResult = hashService.hash(secondPlaintext);
-
-    assertEquals(plaintext, result);
-    assertEquals(secondPlaintext, secondResult);
-
-    assertEquals(result, secondResult);
-  }
-
-  @Test
-  void testHashDifferent() {
-    String plaintext = "password";
-    String secondPlaintext = "secondPassword";
-
-    String result = hashService.hash(plaintext);
-    String secondResult = hashService.hash(secondPlaintext);
-
-    assertEquals(plaintext, result);
-    assertEquals(secondPlaintext, secondResult);
-
-    assertNotEquals(result, secondResult);
-  }
-
-  @Test
-  void testHashWithMistakesDisabled() {
-    String plaintext = "Password";
-    String hashed = hashService.hash(plaintext);
-
-    assertTrue(hashService.isMatch(plaintext, hashed));
-
-    String capsLock = "pASSWORD";
-    assertFalse(hashService.isMatch(capsLock, hashed));
-
-    String extraFirstCharacter = "*Password";
-    assertFalse(hashService.isMatch(extraFirstCharacter, hashed));
-
-    String extraLastCharacter = "Password-";
-    assertFalse(hashService.isMatch(extraLastCharacter, hashed));
-
-    String firstCharacterCaseSwap = "password";
-    assertFalse(hashService.isMatch(firstCharacterCaseSwap, hashed));
-  }
-
-  @Test
-  void testHashWithMistakesEnabled() {
-    HashService hashService = new SimpleHashService(true, true);
-
-    String plaintext = "Password";
-    String hashed = hashService.hash(plaintext);
-
-    assertTrue(hashService.isMatch(plaintext, hashed));
-
-    String capsLock = "pASSWORD";
-    assertTrue(hashService.isMatch(capsLock, hashed));
-
-    String extraFirstCharacter = "*Password";
-    assertTrue(hashService.isMatch(extraFirstCharacter, hashed));
-
-    String extraLastCharacter = "Password-";
-    assertTrue(hashService.isMatch(extraLastCharacter, hashed));
-
-    String firstCharacterCaseSwap = "password";
-    assertTrue(hashService.isMatch(firstCharacterCaseSwap, hashed));
-  }
-
-  @Test
-  void testHashWithMistakesEnabledIncorrect() {
-    HashService hashService = new SimpleHashService(true, true);
-
-    String plaintext = "Password";
-    String hashed = hashService.hash(plaintext);
-
-    assertTrue(hashService.isMatch(plaintext, hashed));
-
-    String incorrectCapsLock = "PASSWORD";
-    assertFalse(hashService.isMatch(incorrectCapsLock, hashed));
-
-    String incorrectExtraFirstCharacter = "*2Password";
-    assertFalse(hashService.isMatch(incorrectExtraFirstCharacter, hashed));
-
-    String incorrectExtraLastCharacter = "Password-x";
-    assertFalse(hashService.isMatch(incorrectExtraLastCharacter, hashed));
-
-    String incorrectFirstCharacterCaseSwap = "passworD";
-    assertFalse(hashService.isMatch(incorrectFirstCharacterCaseSwap, hashed));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
 
     <!-- Dependency versions -->
     <aws.version>2.17.290</aws.version>
-    <bcrypt.version>0.9.0</bcrypt.version>
     <dagger.version>2.44</dagger.version>
     <dropwizard.version>2.1.2</dropwizard.version>
     <failsafe.version>2.4.4</failsafe.version>
@@ -73,6 +72,7 @@
     <jwt.version>4.0.0</jwt.version>
     <mockito.version>4.8.0</mockito.version>
     <mongodb.version>4.7.2</mongodb.version>
+    <password4j.version>1.6.1</password4j.version>
     <retrofit.version>2.9.0</retrofit.version>
     <swagger.version>2.2.3</swagger.version>
   </properties>
@@ -299,11 +299,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>at.favre.lib</groupId>
-        <artifactId>bcrypt</artifactId>
-        <version>${bcrypt.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.auth0</groupId>
         <artifactId>java-jwt</artifactId>
         <version>${jwt.version}</version>
@@ -337,6 +332,17 @@
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.password4j</groupId>
+        <artifactId>password4j</artifactId>
+        <version>${password4j.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.sanctionco.jmail</groupId>


### PR DESCRIPTION
### This PR addresses:
<!-- Put a reference to an issue number here,
     or a short description of what this PR addresses if no issue exists. -->
Replace internal bcrypt hash implementation with `Password4j`. This is more maintained and also includes other algorithms we can use.

### I have verified that:
<!-- Ensure all of these boxes are checked. -->
- [x] All related unit tests have been updated/created
- [x] All related integration tests have been updated/created
- [x] I have updated any relevant documentation in the `docs/` directory
- [x] If I made any additions/changes to the config file, I've updated the Helm chart in `scripts/deploy/helm`
- [x] If necessary, I've updated `CHANGELOG.md` with a description of my change

### Additional Notes
<!-- Put any other additional notes here for reviewers. -->
